### PR TITLE
Gallery demo

### DIFF
--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -30,7 +30,7 @@ function makeContractHost(E, evaluate) {
   const inviteAssay = inviteIssuer.getAssay();
 
   function redeem(allegedInvitePayment) {
-    const allegedInviteAmount = allegedInvitePayment.getXferBalance();
+    const allegedInviteAmount = allegedInvitePayment.getBalance();
     const inviteAmount = inviteAssay.vouch(allegedInviteAmount);
     insist(!inviteAssay.isEmpty(inviteAmount))`\
 No invites left`;

--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -9,6 +9,7 @@ import { insist } from '../util/insist';
 import { mustBeSameStructure, allComparable } from '../util/sameStructure';
 import { makeUniAssayMaker } from './assays';
 import { makeMint } from './issuers';
+import { makeBasicMintController } from './mintController';
 import makePromise from '../util/makePromise';
 
 function makeContractHost(E, evaluate) {
@@ -25,7 +26,11 @@ function makeContractHost(E, evaluate) {
     return seatDesc;
   }
   const makeUniAssay = makeUniAssayMaker(descriptionCoercer);
-  const inviteMint = makeMint('contract host', makeUniAssay);
+  const inviteMint = makeMint(
+    'contract host',
+    makeBasicMintController,
+    makeUniAssay,
+  );
   const inviteIssuer = inviteMint.getIssuer();
   const inviteAssay = inviteIssuer.getAssay();
 

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -112,6 +112,8 @@ Description must be truthy: ${description}`;
   }
 
   let destroyed = false;
+  // eventually, we will want to be able to credibly destroy the mint
+  // eslint-disable-next-line no-unused-vars
   function destroyMint() {
     destroyed = true;
   }

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -111,39 +111,24 @@ Description must be truthy: ${description}`;
     return amount;
   }
 
-  let destroyed = false;
-  // eventually, we will want to be able to credibly destroy the mint
-  // eslint-disable-next-line no-unused-vars
-  function destroyMint() {
-    destroyed = true;
-  }
-  function insistMintNotDestroyed() {
-    insist(!destroyed)`mint has been destroyed`;
-  }
-
   const mint = harden({
     getIssuer() {
-      insistMintNotDestroyed();
       return issuer;
     },
     destroyAll() {
-      insistMintNotDestroyed();
       mintController.destroyAll();
     },
     destroy(amount) {
-      insistMintNotDestroyed();
       amount = assay.coerce(amount);
       // for non-fungible tokens that are unique, destroy them by removing them from
       // the purses/payments that they live in
       mintController.destroy(amount);
     },
     revoke(amount) {
-      insistMintNotDestroyed();
       this.destroy(amount);
       return mint(amount);
     },
     mint(initialBalance, _name = 'a purse') {
-      insistMintNotDestroyed();
       initialBalance = assay.coerce(initialBalance);
       _name = `${_name}`;
 

--- a/core/mintController.js
+++ b/core/mintController.js
@@ -1,0 +1,91 @@
+import { makePrivateName } from '../util/PrivateName';
+
+import { getString } from '../more/pixels/types/pixel';
+
+export function makeMintController(assay) {
+  // Map from purse or payment to the rights it currently
+  // holds. Rights can move via payments
+
+  // purse/payment to amount
+  let rights = makePrivateName();
+
+  // pixel to purse/payment
+  const pixelToPursePayment = new Map();
+
+  function setLocation(amount, pursePayment) {
+    // purse/payment is the key of rights
+    amount = assay.coerce(amount);
+    const pixelList = assay.quantity(amount);
+    for (const pixel of pixelList) {
+      pixelToPursePayment.set(getString(pixel), pursePayment);
+    }
+  }
+
+  function destroy(amount) {
+    // amount must only contain one pixel
+    const pixelList = assay.quantity(amount);
+    // assume length === 1 for now
+
+    const pixel = pixelList[0];
+    const location = pixelToPursePayment.get(getString(pixel));
+    // amount is guaranteed to be there
+    // eslint-disable-next-line no-use-before-define
+    amount = assay.coerce(amount);
+    const srcOldRightsAmount = rights.get(location);
+    // eslint-disable-next-line no-use-before-define
+    const srcNewRightsAmount = assay.without(srcOldRightsAmount, amount);
+
+    // ///////////////// commit point //////////////////
+    // All queries above passed with no side effects.
+    // During side effects below, any early exits should be made into
+    // fatal turn aborts.
+
+    rights.set(location, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, location);
+
+    // delete pixel from pixelToPursePayment
+    pixelToPursePayment.delete(pixel);
+  }
+
+  function destroyAll() {
+    rights = makePrivateName(); // reset rights
+  }
+
+  function recordPayment(src, payment, amount, srcNewRightsAmount) {
+    rights.set(src, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, src);
+    rights.init(payment, amount);
+    setLocation(amount, payment);
+  }
+
+  function recordDeposit(
+    srcPayment,
+    srcNewRightsAmount,
+    purse,
+    purseNewRightsAmount,
+  ) {
+    rights.set(srcPayment, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, srcPayment);
+    rights.set(purse, purseNewRightsAmount);
+    setLocation(purseNewRightsAmount, purse);
+  }
+
+  function recordMint(purse, initialAmount) {
+    rights.init(purse, initialAmount);
+    setLocation(initialAmount, purse);
+  }
+
+  function getAmount(pursePayment) {
+    return rights.get(pursePayment);
+  }
+
+  const mintController = {
+    destroy,
+    destroyAll,
+    recordPayment,
+    recordDeposit,
+    recordMint,
+    getAmount,
+  };
+  return mintController;
+}

--- a/core/mintController.js
+++ b/core/mintController.js
@@ -1,61 +1,23 @@
 import { makePrivateName } from '../util/PrivateName';
 
-import { getString } from '../more/pixels/types/pixel';
-
-export function makeMintController(assay) {
+export function makeBasicMintController() {
   // Map from purse or payment to the rights it currently
   // holds. Rights can move via payments
 
   // purse/payment to amount
   let rights = makePrivateName();
 
-  // pixel to purse/payment
-  const pixelToPursePayment = new Map();
-
-  function setLocation(amount, pursePayment) {
-    // purse/payment is the key of rights
-    amount = assay.coerce(amount);
-    const pixelList = assay.quantity(amount);
-    for (const pixel of pixelList) {
-      pixelToPursePayment.set(getString(pixel), pursePayment);
-    }
+  function recordPayment(src, payment, amount, srcNewRightsAmount) {
+    rights.set(src, srcNewRightsAmount);
+    rights.init(payment, amount);
   }
 
-  function destroy(amount) {
-    // amount must only contain one pixel
-    const pixelList = assay.quantity(amount);
-    // assume length === 1 for now
-
-    const pixel = pixelList[0];
-    const location = pixelToPursePayment.get(getString(pixel));
-    // amount is guaranteed to be there
-    // eslint-disable-next-line no-use-before-define
-    amount = assay.coerce(amount);
-    const srcOldRightsAmount = rights.get(location);
-    // eslint-disable-next-line no-use-before-define
-    const srcNewRightsAmount = assay.without(srcOldRightsAmount, amount);
-
-    // ///////////////// commit point //////////////////
-    // All queries above passed with no side effects.
-    // During side effects below, any early exits should be made into
-    // fatal turn aborts.
-
-    rights.set(location, srcNewRightsAmount);
-    setLocation(srcNewRightsAmount, location);
-
-    // delete pixel from pixelToPursePayment
-    pixelToPursePayment.delete(pixel);
+  function destroy(_amount) {
+    throw new Error('destroy is not implemented');
   }
 
   function destroyAll() {
     rights = makePrivateName(); // reset rights
-  }
-
-  function recordPayment(src, payment, amount, srcNewRightsAmount) {
-    rights.set(src, srcNewRightsAmount);
-    setLocation(srcNewRightsAmount, src);
-    rights.init(payment, amount);
-    setLocation(amount, payment);
   }
 
   function recordDeposit(
@@ -65,14 +27,11 @@ export function makeMintController(assay) {
     purseNewRightsAmount,
   ) {
     rights.set(srcPayment, srcNewRightsAmount);
-    setLocation(srcNewRightsAmount, srcPayment);
     rights.set(purse, purseNewRightsAmount);
-    setLocation(purseNewRightsAmount, purse);
   }
 
   function recordMint(purse, initialAmount) {
     rights.init(purse, initialAmount);
-    setLocation(initialAmount, purse);
   }
 
   function getAmount(pursePayment) {

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -11,8 +11,8 @@ function build(E, log) {
   // it.
   function showPaymentBalance(name, paymentP) {
     return E(paymentP)
-      .getXferBalance()
-      .then(amount => log(name, ' xfer balance ', amount));
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
   }
   // TODO BUG: All callers should wait until settled before doing
   // anything that would change the balance before show*Balance* reads
@@ -20,11 +20,8 @@ function build(E, log) {
   function showPurseBalances(name, purseP) {
     return Promise.all([
       E(purseP)
-        .getXferBalance()
-        .then(amount => log(name, ' xfer balance ', amount)),
-      E(purseP)
-        .getUseBalance()
-        .then(amount => log(name, ' use balance ', amount)),
+        .getBalance()
+        .then(amount => log(name, ' balance ', amount)),
     ]);
   }
 

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -72,6 +72,7 @@ function build(E, log) {
   function mintTestNumber(mint) {
     log('starting mintTestNumber');
     const mMintP = E(mint).makeMint('quatloos');
+    mMintP.then(newMint => console.log(newMint));
 
     const alicePurseP = E(mMintP).mint(1000, 'alice');
     const paymentP = E(alicePurseP).withdraw(50);

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -14,8 +14,8 @@ function makeAliceMaker(E, host, log) {
   // it.
   function showPaymentBalance(name, paymentP) {
     return E(paymentP)
-      .getXferBalance()
-      .then(amount => log(name, ' xfer balance ', amount));
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
   }
 
   return harden({
@@ -48,9 +48,7 @@ function makeAliceMaker(E, host, log) {
           log('++ alice.acceptInvite starting');
           showPaymentBalance('alice invite', allegedInvitePaymentP);
 
-          const allegedInviteAmountP = E(
-            allegedInvitePaymentP,
-          ).getXferBalance();
+          const allegedInviteAmountP = E(allegedInvitePaymentP).getBalance();
 
           const verifiedInviteP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
@@ -112,9 +110,7 @@ function makeAliceMaker(E, host, log) {
           log('++ alice.acceptOptionDirectly starting');
           showPaymentBalance('alice invite', allegedInvitePaymentP);
 
-          const allegedInviteAmountP = E(
-            allegedInvitePaymentP,
-          ).getXferBalance();
+          const allegedInviteAmountP = E(allegedInvitePaymentP).getBalance();
 
           const verifiedInvitePaymentP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
@@ -174,7 +170,7 @@ function makeAliceMaker(E, host, log) {
         acceptOptionForFred(allegedInvitePaymentP) {
           log('++ alice.acceptOptionForFred starting');
           const finNeededP = E(E(optFinIssuerP).getAssay()).make(55);
-          const inviteNeededP = E(allegedInvitePaymentP).getXferBalance();
+          const inviteNeededP = E(allegedInvitePaymentP).getBalance();
 
           const terms = harden([finNeededP, inviteNeededP]);
           const invitesP = E(escrowExchangeInstallationP).spawn(terms);

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -53,9 +53,7 @@ function makeFredMaker(E, host, log) {
             quantity: 55,
           });
 
-          const allegedSaleAmountP = E(
-            allegedSaleInvitePaymentP,
-          ).getXferBalance();
+          const allegedSaleAmountP = E(allegedSaleInvitePaymentP).getBalance();
 
           const verifiedSaleInvitePaymentP = E.resolve(allegedSaleAmountP).then(
             allegedSaleInviteAmount => {

--- a/demo/gallery/README.md
+++ b/demo/gallery/README.md
@@ -1,0 +1,51 @@
+# Pixel Gallery Demo
+
+This demo is roughly based on [Reddit's
+r/Place](https://en.wikipedia.org/wiki/Place_(Reddit)), but has a 
+number of additional features that showcase the unique affordances of
+the Agoric platform, including: higher-order contracts, easy creation
+of new assets, and safe code reusability.
+
+## Pixels
+The base asset a pixelList (an array of
+pixels). The holder of a pixel is able to change the color of the
+pixel by splitting the pixelList up into the useRight (the right to
+color) and a transfer right (the right to transfer the pixel). The
+holder of the use right can send a payment of the right to the Gallery
+(the creator the pixel canvas) to color. 
+
+When the transfer right is sent as a payment to another user, that
+user can do turn the transfer right in to the Gallery to get a full
+pixel back, thus revoking any coloring rights that may be in the hands
+of other users. 
+
+## Dust
+We also have a currency called Dust (Pixel Dust, heh heh). Users do not start out with any Dust - they only start out with access to the faucet. As described in more detail below, they can sell the pixels that they get for free from the faucet back to the Gallery in order to earn Dust.  
+
+## Gallery
+
+At the start, all pixels and all color rights are held by the Gallery.
+The Gallery provides a faucet that allows users to get a pixel at a
+time for free. The Gallery has a queue of all the pixels ordered by
+least recently used (at the start, this is all the pixels in an
+unusual order), and takes from the front of this LRU queue to provide a pixel to the faucet.
+
+The user eventually gets a handful of pixels from the faucet (in the
+future, this would be rate-limited per user), but at this point, it is unlikely that the user is able to draw
+anything interesting. Hopefully, this will incentivize them to keep
+playing (“gotta collect them all”) rather than deter them. 
+
+## Further Gameplay
+
+In order to amass the pixels that they want in order to draw their masterpiece, the user will need to sell some pixels to get our currency, Dust. (The user does not start out with any money.) Our Gallery will always buy pixels back, but it values pixels near the center much more than pixels on the periphery. This will incentivize people to keep hitting the faucet because they might get a “valuable” pixel in the next go. 
+
+In order to sell pixels, the user must create an ask in our order book. The Gallery will always have a bid (request to buy) for all pixels, but the price should be relatively low, lower than selling to another user (this will need to be done after experimentation, not sure how to guarantee it now). 
+
+Now that the user has some Dust, how can they buy their pixels? The pixel canvas will have an on-hover attribute that shows the x, y coordinates of the hovered-over pixel. The user should be able to look at the canvas to see what they want to buy, and record the coordinates. Then, they can create a bid in the order book for that pixel or sell it to the Gallery for a relatively low price. 
+
+The user should be able to put their color rights into our ERTP covered call and other contract components and create things like options. 
+
+For examples of how the ERTP assets work, see:
+  test/demo/test-gallery-demo.js 
+and:
+  test/more/pixels/test-gallery.js

--- a/demo/gallery/bootstrap.js
+++ b/demo/gallery/bootstrap.js
@@ -35,7 +35,7 @@ function build(E, log) {
     async bootstrap(argv, vats) {
       const canvasSize = 10;
       function stateChangeHandler(_newState) {
-          // does nothing in this test
+        // does nothing in this test
       }
 
       switch (argv[0]) {

--- a/demo/gallery/bootstrap.js
+++ b/demo/gallery/bootstrap.js
@@ -34,19 +34,22 @@ function build(E, log) {
   const obj0 = {
     async bootstrap(argv, vats) {
       const canvasSize = 10;
+      function stateChangeHandler(_newState) {
+          // does nothing in this test
+      }
 
       switch (argv[0]) {
         case 'tapFaucet': {
           log('starting tapFaucet');
           const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const gallery = makeGallery(E, canvasSize);
+          const gallery = makeGallery(stateChangeHandler, canvasSize);
           log('alice is made');
           return testTapFaucet(aliceMaker, gallery);
         }
         case 'aliceChangesColor': {
           log('starting aliceChangesColor');
           const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const gallery = makeGallery(E, canvasSize);
+          const gallery = makeGallery(stateChangeHandler, canvasSize);
           log('alice is made');
           return testAliceChangesColor(aliceMaker, gallery);
         }
@@ -54,7 +57,7 @@ function build(E, log) {
           log('starting aliceSendsOnlyUseRight');
           const aliceMaker = await E(vats.alice).makeAliceMaker();
           const bobMaker = await E(vats.bob).makeBobMaker();
-          const gallery = makeGallery(E, canvasSize);
+          const gallery = makeGallery(stateChangeHandler, canvasSize);
           log('alice is made');
           return testAliceSendsOnlyUseRight(aliceMaker, bobMaker, gallery);
         }
@@ -62,7 +65,7 @@ function build(E, log) {
           log('starting galleryRevokes');
           const aliceMaker = await E(vats.alice).makeAliceMaker();
           const bobMaker = await E(vats.bob).makeBobMaker();
-          const gallery = makeGallery(E, canvasSize);
+          const gallery = makeGallery(stateChangeHandler, canvasSize);
           return testGalleryRevokes(aliceMaker, bobMaker, gallery);
         }
         default: {

--- a/demo/gallery/bootstrap.js
+++ b/demo/gallery/bootstrap.js
@@ -36,6 +36,12 @@ function build(E, log) {
     const rawPixel = alicePixelAmount.quantity[0];
     log(`current color ${gallery.userFacet.getColor(rawPixel.x, rawPixel.y)}`);
   }
+  async function testAliceSendsOnlyUseRight(aliceMaker, bobMaker, gallery) {
+    log('starting testAliceSendsOnlyUseRight');
+    const aliceP = E(aliceMaker).make(gallery.userFacet);
+    const bobP = E(bobMaker).make(gallery.userFacet);
+    await E(aliceP).doSendOnlyUseRight(bobP);
+  }
 
   const obj0 = {
     async bootstrap(argv, vats) {
@@ -55,6 +61,14 @@ function build(E, log) {
           const gallery = makeGallery(E, canvasSize);
           log('alice is made');
           return testAliceChangesColor(aliceMaker, gallery);
+        }
+        case 'aliceSendsOnlyUseRight': {
+          log('aliceSendsOnlyUseRight');
+          const aliceMaker = await E(vats.alice).makeAliceMaker();
+          const bobMaker = await E(vats.bob).makeBobMaker();
+          const gallery = makeGallery(E, canvasSize);
+          log('alice is made');
+          return testAliceSendsOnlyUseRight(aliceMaker, bobMaker, gallery);
         }
         default: {
           throw new Error(`unrecognized argument value ${argv[0]}`);

--- a/demo/gallery/bootstrap.js
+++ b/demo/gallery/bootstrap.js
@@ -1,0 +1,82 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeGallery } from '../../more/pixels/gallery';
+
+function build(E, log) {
+  // TODO BUG: All callers should wait until settled before doing
+  // anything that would change the balance before show*Balance* reads
+  // it.
+  function showPaymentBalance(name, paymentP) {
+    return E(paymentP)
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
+  }
+  // TODO BUG: All callers should wait until settled before doing
+  // anything that would change the balance before show*Balance* reads
+  // it.
+  function showPurseBalances(name, purseP) {
+    return Promise.all([
+      E(purseP)
+        .getBalance()
+        .then(amount => log(name, ' balance ', amount)),
+    ]);
+  }
+
+  function testTapFaucet(aliceMaker, gallery) {
+    log('starting testTapFaucet');
+    const aliceP = E(aliceMaker).make(gallery.userFacet);
+    return E(aliceP).doTapFaucet();
+  }
+  async function testAliceChangesColor(aliceMaker, gallery) {
+    log('starting testAliceChangesColor');
+    const aliceP = E(aliceMaker).make(gallery.userFacet);
+    const alicePixelAmount = await E(aliceP).doChangeColor();
+    const rawPixel = alicePixelAmount.quantity[0];
+    log(`current color ${gallery.userFacet.getColor(rawPixel.x, rawPixel.y)}`);
+  }
+
+  const obj0 = {
+    async bootstrap(argv, vats) {
+      const canvasSize = 10;
+
+      switch (argv[0]) {
+        case 'tapFaucet': {
+          log('starting tapFaucet');
+          const aliceMaker = await E(vats.alice).makeAliceMaker();
+          const gallery = makeGallery(E, canvasSize);
+          log('alice is made');
+          return testTapFaucet(aliceMaker, gallery);
+        }
+        case 'aliceChangesColor': {
+          log('starting aliceChangesColor');
+          const aliceMaker = await E(vats.alice).makeAliceMaker();
+          const gallery = makeGallery(E, canvasSize);
+          log('alice is made');
+          return testAliceChangesColor(aliceMaker, gallery);
+        }
+        default: {
+          throw new Error(`unrecognized argument value ${argv[0]}`);
+        }
+      }
+    },
+  };
+  return harden(obj0);
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  log(`=> setup called`);
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/demo/gallery/vat-alice.js
+++ b/demo/gallery/vat-alice.js
@@ -3,6 +3,8 @@
 
 import harden from '@agoric/harden';
 
+import { insist } from '../../util/insist';
+
 function makeAliceMaker(E, log) {
   // TODO BUG: All callers should wait until settled before doing
   // anything that would change the balance before show*Balance* reads
@@ -26,15 +28,122 @@ function makeAliceMaker(E, log) {
           const pixelPaymentP = E(gallery).tapFaucet();
           log('tapped Faucet');
 
-          // skip getExclusive
-          const { useRightPayment } = await E(
+          const pixelIssuer = E(pixelPaymentP).getIssuer();
+          const exclusivePixelPaymentP = E(pixelIssuer).getExclusiveAll(
+            pixelPaymentP,
+          );
+
+          const useRightTransferRightBundleP = await E(
             gallery,
-          ).transformToTransferAndUse(pixelPaymentP);
+          ).transformToTransferAndUse(exclusivePixelPaymentP);
+
+          const {
+            useRightPayment: useRightPaymentP,
+          } = useRightTransferRightBundleP;
+
+          const useRightIssuer = E(useRightPaymentP).getIssuer();
+          const exclusiveUseRightPaymentP = E(useRightIssuer).getExclusiveAll(
+            useRightPaymentP,
+          );
+
           const changedAmount = await E(gallery).changeColor(
-            useRightPayment,
+            exclusiveUseRightPaymentP,
             '#000000',
           );
           return changedAmount;
+        },
+        async doSendOnlyUseRight(bob) {
+          log('++ alice.doOnlySendUseRight starting');
+          const pixelPaymentP = E(gallery).tapFaucet();
+          log('tapped Faucet');
+
+          const pixelIssuer = E(pixelPaymentP).getIssuer();
+          const exclusivePixelPaymentP = await E(pixelIssuer).getExclusiveAll(
+            pixelPaymentP,
+          );
+
+          const amount = await E(exclusivePixelPaymentP).getBalance();
+
+          const rawPixel = amount.quantity[0];
+
+          const origColor = await E(gallery).getColor(rawPixel.x, rawPixel.y);
+
+          log(
+            `pixel x:${rawPixel.x}, y:${
+              rawPixel.y
+            } has original color ${origColor}`,
+          );
+
+          const {
+            useRightPayment: useRightPaymentP,
+            transferRightPayment: transferRightPaymentP,
+          } = await E(gallery).transformToTransferAndUse(
+            exclusivePixelPaymentP,
+          );
+
+          const useRightIssuer = E(useRightPaymentP).getIssuer();
+          const exclusiveUseRightPaymentP = E(useRightIssuer).getExclusiveAll(
+            useRightPaymentP,
+          );
+
+          const transferRightIssuer = E(transferRightPaymentP).getIssuer();
+          const exclusiveTransferRightPaymentP = E(
+            transferRightIssuer,
+          ).getExclusiveAll(transferRightPaymentP);
+
+          // we have gotten exclusive access to both the useRight and
+          // the transferRight payments.
+
+          // send useRightPayment to Bob
+          // Alice keeps transferRightPayment
+          const result = await E(bob).receiveUseRight(
+            exclusiveUseRightPaymentP,
+          );
+          const bobsRawPixel = result.quantity[0];
+          insist(
+            bobsRawPixel.x === rawPixel.x && bobsRawPixel.y === rawPixel.y,
+          );
+          const bobsColor = await E(gallery).getColor(rawPixel.x, rawPixel.y);
+          log(
+            `pixel x:${rawPixel.x}, y:${
+              rawPixel.y
+            } changed to bob's color ${bobsColor}`,
+          );
+
+          // alice takes the right back
+          const pixelPayment2P = await E(gallery).transformToPixel(
+            exclusiveTransferRightPaymentP,
+          );
+          const exclusivePixelPayment2P = await E(pixelIssuer).getExclusiveAll(
+            pixelPayment2P,
+          );
+          const { useRightPayment: useRightPayment2P } = await E(
+            gallery,
+          ).transformToTransferAndUse(exclusivePixelPayment2P);
+
+          const exclusiveUseRightPayment2P = await E(
+            useRightIssuer,
+          ).getExclusiveAll(useRightPayment2P);
+
+          const changedAmount = await E(gallery).changeColor(
+            exclusiveUseRightPayment2P,
+            '#9FBF95', // a light green
+          );
+
+          const alicesColor = await E(gallery).getColor(rawPixel.x, rawPixel.y);
+          log(
+            `pixel x:${rawPixel.x}, y:${
+              rawPixel.y
+            } changed to alice's color ${alicesColor}`,
+          );
+
+          // tell bob to try to color, he can't
+          return E(bob)
+            .tryToColor()
+            .then(
+              _res => log('uh oh, bob was able to color'),
+              rej => log(`bob was unable to color: ${rej}`),
+            );
         },
       });
       return alice;

--- a/demo/gallery/vat-alice.js
+++ b/demo/gallery/vat-alice.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2013 Google Inc, under Apache License 2.0
+// Copyright (C) 2018 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+function makeAliceMaker(E, log) {
+  // TODO BUG: All callers should wait until settled before doing
+  // anything that would change the balance before show*Balance* reads
+  // it.
+  function showPaymentBalance(name, paymentP) {
+    return E(paymentP)
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
+  }
+
+  return harden({
+    make(gallery) {
+      const alice = harden({
+        doTapFaucet() {
+          log('++ alice.doTapFaucet starting');
+          const pixelPaymentP = E(gallery).tapFaucet();
+          showPaymentBalance('pixel from faucet', pixelPaymentP);
+        },
+        async doChangeColor() {
+          log('++ alice.doChangeColor starting');
+          const pixelPaymentP = E(gallery).tapFaucet();
+          log('tapped Faucet');
+
+          // skip getExclusive
+          const { useRightPayment } = await E(
+            gallery,
+          ).transformToTransferAndUse(pixelPaymentP);
+          const changedAmount = await E(gallery).changeColor(
+            useRightPayment,
+            '#000000',
+          );
+          return changedAmount;
+        },
+      });
+      return alice;
+    },
+  });
+}
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(syscall, state, E =>
+    harden({
+      makeAliceMaker() {
+        return harden(makeAliceMaker(E, log));
+      },
+    }),
+  );
+}
+export default harden(setup);

--- a/demo/gallery/vat-bob.js
+++ b/demo/gallery/vat-bob.js
@@ -18,8 +18,10 @@ function makeBobMaker(E, log) {
         async receiveUseRight(useRightPaymentP) {
           log('++ bob.receiveUseRight starting');
 
-          const useRightIssuer = E(useRightPaymentP).getIssuer();
+          const { useRightIssuer } = await E(gallery).getIssuers();
           const useRightPurse = E(useRightIssuer).makeEmptyPurse();
+          // does bob know the amount that he is getting?
+          // use getExclusive() instead
           const exclusiveUseRightPaymentP = E(useRightIssuer).getExclusiveAll(
             useRightPaymentP,
           );

--- a/demo/gallery/vat-bob.js
+++ b/demo/gallery/vat-bob.js
@@ -1,0 +1,140 @@
+// Copyright (C) 2013 Google Inc, under Apache License 2.0
+// Copyright (C) 2018 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeCollect } from '../../core/contractHost';
+
+function makeBobMaker(E, host, log) {
+  const collect = makeCollect(E, log);
+
+  return harden({
+    make(
+      escrowExchangeInstallationP,
+      coveredCallInstallationP,
+      timerP,
+      myMoneyPurseP,
+      myPixelListPurseP,
+    ) {
+      const moneyIssuerP = E(myMoneyPurseP).getIssuer();
+      const moneyNeededP = E(E(moneyIssuerP).getAssay()).make(10);
+
+      const pixelListIssuerP = E(myPixelListPurseP).getIssuer();
+      const pixelsNeededP = E(E(pixelListIssuerP).getAssay()).make([
+        { x: 1, y: 1 },
+      ]);
+
+      const bob = harden({
+        /**
+         * This is not an imperative to Bob to buy something but rather
+         * the opposite. It is a request by a client to buy something from
+         * Bob, and therefore a request that Bob sell something. OO naming
+         * is a bit confusing here.
+         */
+        async buy(pixelList, paymentAmount, paymentP) {
+          log('++ bob.buy starting');
+          return E.resolve(pixelListIssuerP).then(issuer => {
+            const depositResultP = E(myMoneyPurseP).deposit(
+              paymentAmount,
+              paymentP,
+            );
+            log('++ deposit');
+            const pixelAmount = {
+              label: {
+                issuer,
+                description: 'pixelList',
+              },
+              quantity: pixelList,
+            };
+            const withdrawalResultP = E(myPixelListPurseP).withdraw(
+              pixelAmount,
+            );
+            log('++ withdrawal');
+            return Promise.all([depositResultP, withdrawalResultP]).then(
+              _ => 'exchange successful',
+            );
+          });
+        },
+
+        tradeWell(alice) {
+          log('++ bob.tradeWell starting');
+          // Alice has 0, 0; 0, 1
+          // bob has 1, 0; 1, 1
+
+          // bob will be offering a pixel for money
+          const terms = harden([moneyNeededP, pixelsNeededP]);
+          const invitesP = E(escrowExchangeInstallationP).spawn(terms);
+          const aliceInviteP = invitesP.then(invites => invites[0]);
+          const bobInviteP = invitesP.then(invites => invites[1]);
+          const doneP = Promise.all([
+            E(alice).acceptInvite(aliceInviteP),
+            E(bob).acceptInvite(bobInviteP),
+          ]);
+          doneP.then(
+            _res => log('++ bob.tradeWell done'),
+            rej => log('++ bob.tradeWell reject: ', rej),
+          );
+          return doneP;
+        },
+
+        acceptInvite(inviteP) {
+          const seatP = E(host).redeem(inviteP);
+          return E.resolve(pixelsNeededP).then(pixelsNeeded => {
+            const pixelPaymentP = E(myPixelListPurseP).withdraw(pixelsNeeded);
+            E(seatP).offer(pixelPaymentP);
+            return collect(
+              seatP,
+              myMoneyPurseP,
+              myPixelListPurseP,
+              'bob escrow',
+            );
+          });
+        },
+
+        offerAliceOption(alice) {
+          log('++ bob.offerAliceOption starting');
+
+          const terms = harden([
+            escrowExchangeInstallationP,
+            moneyNeededP,
+            pixelsNeededP,
+            timerP,
+            'singularity',
+          ]);
+          const bobInviteP = E(coveredCallInstallationP).spawn(terms);
+          const bobSeatP = E(host).redeem(bobInviteP);
+          return E.resolve(pixelsNeededP).then(pixelsNeeded => {
+            console.log('got pixelsNeeded');
+            const pixelPaymentP = E(myPixelListPurseP).withdraw(pixelsNeeded);
+            const aliceInviteP = E(bobSeatP).offer(pixelPaymentP);
+            const doneP = Promise.all([
+              E(alice).acceptOption(aliceInviteP),
+              collect(bobSeatP, myMoneyPurseP, myPixelListPurseP, 'bob option'),
+            ]);
+            doneP.then(
+              _res => log('++ bob.offerAliceOption done'),
+              rej => log('++ bob.offerAliceOption reject: ', rej),
+            );
+            return doneP;
+          });
+        },
+      });
+      return bob;
+    },
+  });
+}
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(syscall, state, E =>
+    harden({
+      makeBobMaker(host) {
+        return harden(makeBobMaker(E, host, log));
+      },
+    }),
+  );
+}
+export default harden(setup);

--- a/demo/gallery/vat-mint.js
+++ b/demo/gallery/vat-mint.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeMint } from '../../core/issuers';
+
+function build(_E, _log) {
+  return harden({ makeMint });
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/demo/pixel-demo/bootstrap.js
+++ b/demo/pixel-demo/bootstrap.js
@@ -12,8 +12,8 @@ function build(E, log) {
   // it.
   function showPaymentBalance(name, paymentP) {
     return E(paymentP)
-      .getXferBalance()
-      .then(amount => log(name, ' xfer balance ', amount));
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
   }
   // TODO BUG: All callers should wait until settled before doing
   // anything that would change the balance before show*Balance* reads
@@ -21,11 +21,8 @@ function build(E, log) {
   function showPurseBalances(name, purseP) {
     return Promise.all([
       E(purseP)
-        .getXferBalance()
-        .then(amount => log(name, ' xfer balance ', amount)),
-      E(purseP)
-        .getUseBalance()
-        .then(amount => log(name, ' use balance ', amount)),
+        .getBalance()
+        .then(amount => log(name, ' balance ', amount)),
     ]);
   }
 

--- a/demo/pixel-demo/bootstrap.js
+++ b/demo/pixel-demo/bootstrap.js
@@ -5,7 +5,6 @@ import harden from '@agoric/harden';
 import { escrowExchangeSrc } from '../../core/escrow';
 import { coveredCallSrc } from '../../core/coveredCall';
 import { makeWholePixelList } from '../../more/pixels/types/pixelList';
-import { makeMintController } from '../../more/pixels/pixelMintController';
 
 function build(E, log) {
   // TODO BUG: All callers should wait until settled before doing

--- a/demo/pixel-demo/bootstrap.js
+++ b/demo/pixel-demo/bootstrap.js
@@ -5,6 +5,7 @@ import harden from '@agoric/harden';
 import { escrowExchangeSrc } from '../../core/escrow';
 import { coveredCallSrc } from '../../core/coveredCall';
 import { makeWholePixelList } from '../../more/pixels/types/pixelList';
+import { makeMintController } from '../../more/pixels/pixelMintController';
 
 function build(E, log) {
   // TODO BUG: All callers should wait until settled before doing

--- a/demo/pixel-demo/vat-alice.js
+++ b/demo/pixel-demo/vat-alice.js
@@ -14,8 +14,8 @@ function makeAliceMaker(E, host, log) {
   // it.
   function showPaymentBalance(name, paymentP) {
     return E(paymentP)
-      .getXferBalance()
-      .then(amount => log(name, ' xfer balance ', amount));
+      .getBalance()
+      .then(amount => log(name, ' balance ', amount));
   }
 
   return harden({
@@ -48,9 +48,7 @@ function makeAliceMaker(E, host, log) {
           log('++ alice.acceptInvite starting');
           showPaymentBalance('alice invite', allegedInvitePaymentP);
 
-          const allegedInviteAmountP = E(
-            allegedInvitePaymentP,
-          ).getXferBalance();
+          const allegedInviteAmountP = E(allegedInvitePaymentP).getBalance();
 
           const verifiedInviteP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
@@ -117,9 +115,7 @@ function makeAliceMaker(E, host, log) {
           log('++ alice.acceptOptionDirectly starting');
           showPaymentBalance('alice invite', allegedInvitePaymentP);
 
-          const allegedInviteAmountP = E(
-            allegedInvitePaymentP,
-          ).getXferBalance();
+          const allegedInviteAmountP = E(allegedInvitePaymentP).getBalance();
 
           const verifiedInvitePaymentP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
@@ -184,7 +180,7 @@ function makeAliceMaker(E, host, log) {
         acceptOptionForFred(allegedInvitePaymentP) {
           log('++ alice.acceptOptionForFred starting');
           const finNeededP = E(E(optFinIssuerP).getAssay()).make(55);
-          const inviteNeededP = E(allegedInvitePaymentP).getXferBalance();
+          const inviteNeededP = E(allegedInvitePaymentP).getBalance();
 
           const terms = harden([finNeededP, inviteNeededP]);
           const invitesP = E(escrowExchangeInstallationP).spawn(terms);

--- a/demo/pixel-demo/vat-mint.js
+++ b/demo/pixel-demo/vat-mint.js
@@ -3,12 +3,12 @@
 import harden from '@agoric/harden';
 
 import { makeMint } from '../../core/issuers';
-import { makePixelListAssayMaker } from '../../more/pixels/pixelListAssay';
+import { makeCompoundPixelAssayMaker } from '../../more/pixels/pixelAssays';
 import { makeMintController } from '../../more/pixels/pixelMintController';
 
 function build(_E, _log) {
   function makePixelListMint(canvasSize) {
-    const makePixelListAssay = makePixelListAssayMaker(canvasSize);
+    const makePixelListAssay = makeCompoundPixelAssayMaker(canvasSize);
     return makeMint('pixelList', makeMintController, makePixelListAssay);
   }
   return harden({ makePixelListMint, makeMint });

--- a/demo/pixel-demo/vat-mint.js
+++ b/demo/pixel-demo/vat-mint.js
@@ -4,11 +4,12 @@ import harden from '@agoric/harden';
 
 import { makeMint } from '../../core/issuers';
 import { makePixelListAssayMaker } from '../../more/pixels/pixelListAssay';
+import { makeMintController } from '../../more/pixels/pixelMintController';
 
 function build(_E, _log) {
   function makePixelListMint(canvasSize) {
     const makePixelListAssay = makePixelListAssayMaker(canvasSize);
-    return makeMint('pixelList', makePixelListAssay);
+    return makeMint('pixelList', makeMintController, makePixelListAssay);
   }
   return harden({ makePixelListMint, makeMint });
 }

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -11,7 +11,14 @@ import { makeWholePixelList, insistPixelList } from './types/pixelList';
 import { makeMintController } from './pixelMintController';
 import { makeLruQueue } from './lruQueue';
 
-export function makeGallery(E, canvasSize = 10) {
+function mockStateChangeHandler(_newState) {
+  // does nothing
+}
+
+export function makeGallery(
+  stateChangeHandler = mockStateChangeHandler,
+  canvasSize = 10,
+) {
   function getRandomColor() {
     // TODO: actually getRandomColor in a deterministic way
     // return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
@@ -31,8 +38,15 @@ export function makeGallery(E, canvasSize = 10) {
   }
   const state = makeRandomData();
 
+  // provide state the canvas html page
+  function getState() {
+    return JSON.stringify(state);
+  }
+
   function setPixelState(pixel, newColor) {
     state[pixel.x][pixel.y] = newColor;
+    // for now we pass the whole state
+    stateChangeHandler(getState());
   }
 
   // create all pixels (list of raw objs)
@@ -205,11 +219,6 @@ export function makeGallery(E, canvasSize = 10) {
     transferRightMint.destroy(transferRightAmount);
   }
 
-  // provide state the canvas html page
-  function provideState() {
-    return JSON.stringify(state);
-  }
-
   // anyone can getColor, no restrictions, no tokens
   function getColor(x, y) {
     const rawPixel = { x: Nat(x), y: Nat(y) };
@@ -241,7 +250,7 @@ export function makeGallery(E, canvasSize = 10) {
   };
 
   const readFacet = {
-    provideState,
+    getState,
     getColor,
   };
 

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -1,0 +1,176 @@
+import Nat from '@agoric/nat';
+import harden from '@agoric/harden';
+
+import { insist } from '../../util/insist';
+import { makePixelListAssayMaker } from './pixelListAssay';
+import { makeMint } from '../../core/issuers';
+import { makeWholePixelList, insistPixelList } from './types/pixelList';
+
+// NON ERTP
+const canvasSize = 10;
+
+function getRandomColor() {
+  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+}
+
+function makeRandomData() {
+  const pixels = [];
+  for (let x = 0; x < canvasSize; x += 1) {
+    const pixelRow = [];
+    for (let y = 0; y < canvasSize; y += 1) {
+      pixelRow.push(getRandomColor());
+    }
+    pixels.push(pixelRow);
+  }
+  return pixels;
+}
+
+const state = makeRandomData();
+
+function setPixelState(pixel, newColor) {
+  state[pixel.x][pixel.y] = newColor;
+}
+
+// create all pixels (list of raw objs)
+const allPixels = makeWholePixelList(canvasSize);
+
+// START ERTP
+
+const makePixelListAssay = makePixelListAssayMaker(canvasSize, true);
+const makeTransferAssay = makePixelListAssayMaker(canvasSize, false);
+const makeUseAssay = makePixelListAssayMaker(canvasSize, false);
+
+// a pixel represents the right to color and transfer the right to color
+const pixelMint = makeMint('pixels', makePixelListAssay);
+const pixelIssuer = pixelMint.getIssuer();
+const pixelAssay = pixelIssuer.getAssay();
+const pixelLabel = harden({ issuer: pixelIssuer, description: 'pixels' });
+
+const transferRightMint = makeMint('pixelsTransferRights', makeTransferAssay);
+const useRightMint = makeMint('pixelUseRights', makeUseAssay);
+const useRightIssuer = useRightMint.getIssuer();
+const transferRightIssuer = transferRightMint.getIssuer();
+const transferAssay = transferRightIssuer.getAssay();
+
+const allPixelsAmount = harden({
+  label: pixelLabel,
+  quantity: allPixels,
+});
+
+// mint all the pixels that will ever exist
+const galleryPurse = pixelMint.mint(allPixelsAmount, 'gallery');
+
+// get the pixelList from the LRU
+function getPixelPayment(rawPixelList) {
+  insistPixelList(rawPixelList);
+  const pixelAmount = {
+    pixelLabel,
+    quantity: rawPixelList,
+  };
+  const payment = galleryPurse.withdraw(pixelAmount);
+  return payment;
+}
+
+const gallerySplitPixelPurse = pixelIssuer.makeEmptyPurse();
+
+// split pixelList into UseRights and TransferRights
+function transformToTransferAndUse(pixelListPayment) {
+  const pixelListAmount = pixelListPayment.getBalance();
+  pixelIssuer.getExclusive(pixelListPayment);
+  gallerySplitPixelPurse.depositAll(pixelListPayment);
+
+  const { transferAmount, useAmount } = pixelAssay.toTransferAndUseRights(
+    pixelListAmount,
+  );
+
+  const transferRightPurse = transferRightMint.mint(transferAmount);
+  const useRightPurse = useRightMint.mint(useAmount);
+
+  const transferRightPayment = transferRightPurse.withdrawAll('transferRights');
+  const useRightPayment = useRightPurse.withdrawAll('useRights');
+
+  return {
+    transferRightPayment,
+    useRightPayment,
+  };
+}
+
+// merge UseRights and TransferRights into a pixel
+function transformToPixel(useRightPayment, transferRightPayment) {
+  const useAmount = useRightPayment.getBalance();
+  const transferAmount = transferRightPayment.getBalance();
+  useRightIssuer.getExclusive(useRightPayment);
+  transferRightIssuer.getExclusive(transferRightPayment);
+
+  const pixelListAmount = transferAssay.toPixel({
+    useAmount,
+    transferAmount,
+  });
+
+  const pixelPayment = gallerySplitPixelPurse.withdraw(
+    pixelListAmount,
+    'pixels',
+  );
+  return pixelPayment;
+}
+
+function tapFaucet() {
+  const rawPixel = allPixels[Math.floor(Math.random() * allPixels.length)];
+  return getPixelPayment(harden([rawPixel]));
+}
+
+function insistColor(myColor) {
+  const allowedColors = new Map();
+  insist(allowedColors.has(myColor))`color is not allowed`;
+}
+
+const galleryUseRightPurse = useRightIssuer.makeEmptyPurse();
+
+function changeColor(useRightPayment, newColor) {
+  const pixelAmount = useRightPayment.getBalance();
+  const pixelList = pixelAssay.quantity(pixelAmount);
+
+  // if this works, it was a useRightPayment
+  // commit point
+  // don't get exclusive
+  galleryUseRightPurse.depositAll(useRightPayment);
+  insistColor(newColor);
+
+  for (let i = 0; i < pixelList.length; i += 1) {
+    const pixel = pixelList[i];
+    setPixelState(pixel, newColor);
+  }
+}
+
+// provide state the canvas html page
+function provideState() {
+  return JSON.stringify(state);
+}
+
+// anyone can getColor, no restrictions, no tokens
+function getColor(x, y) {
+  const rawPixel = { x: Nat(x), y: Nat(y) };
+  return state[rawPixel.x][rawPixel.y];
+}
+
+function getIssuers() {
+  return {
+    pixelIssuer,
+    useRightIssuer,
+    transferRightIssuer,
+  };
+}
+
+export const userFacet = {
+  changeColor,
+  getColor,
+  tapFaucet,
+  transformToTransferAndUse,
+  transformToPixel,
+  getIssuers,
+};
+
+export const readFacet = {
+  provideState,
+  getColor,
+};

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -1,238 +1,239 @@
 import Nat from '@agoric/nat';
 import harden from '@agoric/harden';
 
-import { insist } from '../../util/insist';
 import { makePixelListAssayMaker } from './pixelListAssay';
 import { makeMint } from '../../core/issuers';
 import { makeWholePixelList, insistPixelList } from './types/pixelList';
-import { makeMintController } from '../../core/mintController';
+import { makeMintController } from './pixelMintController';
 
-// NON ERTP
-const canvasSize = 10;
+export function makeGallery(canvasSize = 10) {
+  function getRandomColor() {
+    return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+  }
 
-function getRandomColor() {
-  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-}
-
-function makeRandomData() {
-  const pixels = [];
-  for (let x = 0; x < canvasSize; x += 1) {
-    const pixelRow = [];
-    for (let y = 0; y < canvasSize; y += 1) {
-      pixelRow.push(getRandomColor());
+  function makeRandomData() {
+    const pixels = [];
+    for (let x = 0; x < canvasSize; x += 1) {
+      const pixelRow = [];
+      for (let y = 0; y < canvasSize; y += 1) {
+        pixelRow.push(getRandomColor());
+      }
+      pixels.push(pixelRow);
     }
-    pixels.push(pixelRow);
+    return pixels;
   }
-  return pixels;
-}
+  const state = makeRandomData();
 
-const state = makeRandomData();
+  function setPixelState(pixel, newColor) {
+    state[pixel.x][pixel.y] = newColor;
+  }
 
-function setPixelState(pixel, newColor) {
-  state[pixel.x][pixel.y] = newColor;
-}
+  // create all pixels (list of raw objs)
+  const allPixels = makeWholePixelList(canvasSize);
 
-// create all pixels (list of raw objs)
-const allPixels = makeWholePixelList(canvasSize);
+  // START ERTP
 
-// START ERTP
+  const makePixelListAssay = makePixelListAssayMaker(canvasSize, true);
+  const makeTransferAssay = makePixelListAssayMaker(canvasSize, false);
+  const makeUseAssay = makePixelListAssayMaker(canvasSize, false);
 
-const makePixelListAssay = makePixelListAssayMaker(canvasSize, true);
-const makeTransferAssay = makePixelListAssayMaker(canvasSize, false);
-const makeUseAssay = makePixelListAssayMaker(canvasSize, false);
+  // a pixel represents the right to color and transfer the right to color
+  const pixelMint = makeMint('pixels', makeMintController, makePixelListAssay);
+  const pixelIssuer = pixelMint.getIssuer();
+  const pixelAssay = pixelIssuer.getAssay();
+  const pixelLabel = harden({ issuer: pixelIssuer, description: 'pixels' });
 
-// a pixel represents the right to color and transfer the right to color
-const { mint: pixelMint } = makeMint(
-  'pixels',
-  makeMintController,
-  makePixelListAssay,
-);
-const pixelIssuer = pixelMint.getIssuer();
-const pixelAssay = pixelIssuer.getAssay();
-const pixelLabel = harden({ issuer: pixelIssuer, description: 'pixels' });
+  const transferRightMint = makeMint(
+    'pixelTransferRights',
+    makeMintController,
+    makeTransferAssay,
+  );
+  const useRightMint = makeMint(
+    'pixelUseRights',
+    makeMintController,
+    makeUseAssay,
+  );
+  const useRightIssuer = useRightMint.getIssuer();
+  const useRightAssay = useRightIssuer.getAssay();
+  const transferRightIssuer = transferRightMint.getIssuer();
+  const transferRightAssay = transferRightIssuer.getAssay();
 
-const { mint: transferRightMint } = makeMint(
-  'pixelTransferRights',
-  makeMintController,
-  makeTransferAssay,
-);
-const { mint: useRightMint } = makeMint(
-  'pixelUseRights',
-  makeMintController,
-  makeUseAssay,
-);
-const useRightIssuer = useRightMint.getIssuer();
-const useRightAssay = useRightIssuer.getAssay();
-const transferRightIssuer = transferRightMint.getIssuer();
-const transferRightAssay = transferRightIssuer.getAssay();
-
-const allPixelsAmount = harden({
-  label: pixelLabel,
-  quantity: allPixels,
-});
-
-// mint all the pixels that will ever exist
-const galleryPurse = pixelMint.mint(allPixelsAmount, 'gallery');
-
-// get the pixelList from the LRU
-function getPixelPayment(rawPixelList) {
-  insistPixelList(rawPixelList, canvasSize);
-  const pixelAmount = {
+  const allPixelsAmount = harden({
     label: pixelLabel,
-    quantity: rawPixelList,
-  };
-  const payment = galleryPurse.withdraw(pixelAmount);
-  return payment;
-}
+    quantity: allPixels,
+  });
 
-const gallerySplitPixelPurse = pixelIssuer.makeEmptyPurse();
+  // mint all the pixels that will ever exist
+  const galleryPurse = pixelMint.mint(allPixelsAmount, 'gallery');
 
-// split pixelList into UseRights and TransferRights
-async function transformToTransferAndUse(pixelListPayment) {
-  const pixelListAmount = pixelListPayment.getBalance();
-  // fail early if empty
-  const pixelList = pixelAssay.quantity(pixelListAmount);
-  if (pixelList.length <= 0) {
-    throw new Error('no pixels to transform');
+  // get the pixelList from the LRU
+  function getPixelPayment(rawPixelList) {
+    insistPixelList(rawPixelList, canvasSize);
+    const pixelAmount = {
+      label: pixelLabel,
+      quantity: rawPixelList,
+    };
+    const payment = galleryPurse.withdraw(pixelAmount);
+    return payment;
   }
 
-  const exclusivePayment = await pixelIssuer.getExclusiveAll(pixelListPayment);
-  await gallerySplitPixelPurse.depositAll(exclusivePayment); // conserve pixels
+  const gallerySplitPixelPurse = pixelIssuer.makeEmptyPurse();
 
-  const { transferAmount, useAmount } = pixelAssay.toTransferAndUseRights(
-    pixelListAmount,
-    useRightAssay,
-    transferRightAssay,
-  );
+  // split pixelList into UseRights and TransferRights
+  async function transformToTransferAndUse(pixelListPayment) {
+    const pixelListAmount = pixelListPayment.getBalance();
+    // fail early if empty
+    const pixelList = pixelAssay.quantity(pixelListAmount);
+    if (pixelList.length <= 0) {
+      throw new Error('no pixels to transform');
+    }
 
-  const transferRightPurse = transferRightMint.mint(transferAmount);
-  const useRightPurse = useRightMint.mint(useAmount);
+    const exclusivePayment = await pixelIssuer.getExclusiveAll(pixelListPayment);
+    await gallerySplitPixelPurse.depositAll(exclusivePayment); // conserve pixels
 
-  const transferRightPayment = await transferRightPurse.withdrawAll(
-    'transferRights',
-  );
-  const useRightPayment = await useRightPurse.withdrawAll('useRights');
-
-  return {
-    transferRightPayment,
-    useRightPayment,
-  };
-}
-
-// merge UseRights and TransferRights into a pixel
-async function transformToPixel(transferRightPayment) {
-  // someone else may have the useRightPayment so we must destroy the
-  // useRight
-
-  // we have an exclusive on the transfer right
-  const transferAmount = transferRightPayment.getBalance();
-  const quantity = transferRightAssay.quantity(transferAmount);
-  await transferRightIssuer.getExclusiveAll(transferRightPayment);
-
-  // create a useRightAmount corresponding to transferRight
-  const useAmount = useRightAssay.make(quantity);
-
-  const pixelListAmount = pixelAssay.coerce(
-    transferRightAssay.toPixel(
-      {
-        useAmount,
-        transferAmount,
-      },
+    const { transferAmount, useAmount } = pixelAssay.toTransferAndUseRights(
+      pixelListAmount,
       useRightAssay,
-      pixelAssay,
-    ),
-  );
+      transferRightAssay,
+    );
 
-  // commit point
-  await useRightMint.destroy(useAmount);
-  await transferRightMint.destroy(transferAmount);
+    const transferRightPurse = transferRightMint.mint(transferAmount);
+    const useRightPurse = useRightMint.mint(useAmount);
 
-  const pixelPayment = await gallerySplitPixelPurse.withdraw(
-    pixelListAmount,
-    'pixels',
-  ); // conserve pixels
-  return pixelPayment;
-}
+    const transferRightPayment = await transferRightPurse.withdrawAll(
+      'transferRights',
+    );
+    const useRightPayment = await useRightPurse.withdrawAll('useRights');
 
-function tapFaucet() {
-  const rawPixel = allPixels[Math.floor(Math.random() * allPixels.length)];
-  return getPixelPayment(harden([rawPixel]));
-}
-
-function insistColor(_myColor) {
-  // const allowedColors = new Map();
-  // insist(allowedColors.has(myColor))`color is not allowed`;
-}
-
-const galleryUseRightPurse = useRightIssuer.makeEmptyPurse();
-
-async function changeColor(useRightPayment, newColor) {
-  const pixelAmount = useRightPayment.getBalance();
-  const pixelList = useRightAssay.quantity(pixelAmount);
-
-  if (pixelList.length <= 0) {
-    throw new Error('no use rights present');
+    return {
+      transferRightPayment,
+      useRightPayment,
+    };
   }
 
-  // if this works, it was a useRightPayment
-  // commit point
-  // don't get exclusive
-  await galleryUseRightPurse.depositAll(useRightPayment);
-  insistColor(newColor);
+  // merge UseRights and TransferRights into a pixel
+  async function transformToPixel(transferRightPayment) {
+    // someone else may have the useRightPayment so we must destroy the
+    // useRight
 
-  for (let i = 0; i < pixelList.length; i += 1) {
-    const pixel = pixelList[i];
-    setPixelState(pixel, newColor);
+    // we have an exclusive on the transfer right
+    const transferAmount = transferRightPayment.getBalance();
+    const quantity = transferRightAssay.quantity(transferAmount);
+    await transferRightIssuer.getExclusiveAll(transferRightPayment);
+
+    // create a useRightAmount corresponding to transferRight
+    const useAmount = useRightAssay.make(quantity);
+
+    const pixelListAmount = pixelAssay.coerce(
+      transferRightAssay.toPixel(
+        {
+          useAmount,
+          transferAmount,
+        },
+        useRightAssay,
+        pixelAssay,
+      ),
+    );
+
+    // commit point
+    await useRightMint.destroy(useAmount);
+    await transferRightMint.destroy(transferAmount);
+
+    const pixelPayment = await gallerySplitPixelPurse.withdraw(
+      pixelListAmount,
+      'pixels',
+    ); // conserve pixels
+    return pixelPayment;
   }
-}
 
-function revokePixel(rawPixel) {
-  const pixelList = harden([rawPixel]);
-  const pixelAmount = pixelAssay.make(pixelList);
-  const useRightAmount = useRightAssay.make(pixelList);
-  const transferRightAmount = transferRightAssay.make(pixelList);
+  function tapFaucet() {
+    const rawPixel = allPixels[Math.floor(Math.random() * allPixels.length)];
+    return getPixelPayment(harden([rawPixel]));
+  }
 
-  pixelMint.destroy(pixelAmount);
-  useRightMint.destroy(useRightAmount);
-  transferRightMint.destroy(transferRightAmount);
-}
+  function insistColor(_myColor) {
+    // const allowedColors = new Map();
+    // insist(allowedColors.has(myColor))`color is not allowed`;
+  }
 
-// provide state the canvas html page
-function provideState() {
-  return JSON.stringify(state);
-}
+  const galleryUseRightPurse = useRightIssuer.makeEmptyPurse();
 
-// anyone can getColor, no restrictions, no tokens
-function getColor(x, y) {
-  const rawPixel = { x: Nat(x), y: Nat(y) };
-  return state[rawPixel.x][rawPixel.y];
-}
+  async function changeColor(useRightPayment, newColor) {
+    const pixelAmount = useRightPayment.getBalance();
+    const pixelList = useRightAssay.quantity(pixelAmount);
 
-function getIssuers() {
-  return {
-    pixelIssuer,
-    useRightIssuer,
-    transferRightIssuer,
+    if (pixelList.length <= 0) {
+      throw new Error('no use rights present');
+    }
+
+    // if this works, it was a useRightPayment
+    // commit point
+    // don't get exclusive
+    await galleryUseRightPurse.depositAll(useRightPayment);
+    insistColor(newColor);
+
+    for (let i = 0; i < pixelList.length; i += 1) {
+      const pixel = pixelList[i];
+      setPixelState(pixel, newColor);
+    }
+  }
+
+  function revokePixel(rawPixel) {
+    const pixelList = harden([rawPixel]);
+    const pixelAmount = pixelAssay.make(pixelList);
+    const useRightAmount = useRightAssay.make(pixelList);
+    const transferRightAmount = transferRightAssay.make(pixelList);
+
+    pixelMint.destroy(pixelAmount);
+    useRightMint.destroy(useRightAmount);
+    transferRightMint.destroy(transferRightAmount);
+  }
+
+  // provide state the canvas html page
+  function provideState() {
+    return JSON.stringify(state);
+  }
+
+  // anyone can getColor, no restrictions, no tokens
+  function getColor(x, y) {
+    const rawPixel = { x: Nat(x), y: Nat(y) };
+    return state[rawPixel.x][rawPixel.y];
+  }
+
+  function getIssuers() {
+    return {
+      pixelIssuer,
+      useRightIssuer,
+      transferRightIssuer,
+    };
+  }
+
+  const userFacet = {
+    changeColor,
+    getColor,
+    tapFaucet,
+    transformToTransferAndUse,
+    transformToPixel,
+    getIssuers,
+    getCanvasSize() {
+      return canvasSize;
+    },
   };
+
+  const adminFacet = {
+    revokePixel,
+  };
+
+  const readFacet = {
+    provideState,
+    getColor,
+  };
+
+  const gallery = {
+    userFacet,
+    adminFacet,
+    readFacet,
+  };
+
+  return gallery;
 }
-
-export const userFacet = {
-  changeColor,
-  getColor,
-  tapFaucet,
-  transformToTransferAndUse,
-  transformToPixel,
-  getIssuers,
-};
-
-export const testFacet = {
-  revokePixel,
-  getCanvasSize() {
-    return canvasSize;
-  },
-};
-
-export const readFacet = {
-  provideState,
-  getColor,
-};

--- a/more/pixels/lruQueue.js
+++ b/more/pixels/lruQueue.js
@@ -7,7 +7,7 @@ import harden from '@agoric/harden';
 // requeuing arbitrary entries to the tail. Initialize by pushing an arbitrary
 // number of items, then call resortArbitrarily() with the number of entries and
 // a step size (something prime and not a multiple of the row size).
-function makeLruQueue() {
+export function makeLruQueue() {
   function makeNode(obj, prev = null, next = null) {
     return { contents: obj, prev, next };
   }
@@ -106,8 +106,5 @@ function makeLruQueue() {
   const lruQueue = harden({ popToTail, requeue });
   const lruQueueBuilder = harden({ push, resortArbitrarily, isEmpty });
 
-  return { lruQueue, lruQueueBuilder };
+  return harden({ lruQueue, lruQueueBuilder });
 }
-harden(makeLruQueue());
-
-export { makeLruQueue };

--- a/more/pixels/pixelAssays.js
+++ b/more/pixels/pixelAssays.js
@@ -13,7 +13,6 @@ import {
   includesPixelList,
   withPixelList,
   withoutPixelList,
-  insistPixelListEqual,
 } from './types/pixelList';
 
 // A pixelList is a naive collection of pixels in the form:

--- a/more/pixels/pixelMintController.js
+++ b/more/pixels/pixelMintController.js
@@ -1,0 +1,91 @@
+import { makePrivateName } from '../../util/PrivateName';
+
+import { getString } from './types/pixel';
+
+export function makeMintController(assay) {
+  // Map from purse or payment to the rights it currently
+  // holds. Rights can move via payments
+
+  // purse/payment to amount
+  let rights = makePrivateName();
+
+  // pixel to purse/payment
+  const pixelToPursePayment = new Map();
+
+  function setLocation(amount, pursePayment) {
+    // purse/payment is the key of rights
+    amount = assay.coerce(amount);
+    const pixelList = assay.quantity(amount);
+    for (const pixel of pixelList) {
+      pixelToPursePayment.set(getString(pixel), pursePayment);
+    }
+  }
+
+  function destroy(amount) {
+    // amount must only contain one pixel
+    const pixelList = assay.quantity(amount);
+    // assume length === 1 for now
+
+    const pixel = pixelList[0];
+    const location = pixelToPursePayment.get(getString(pixel));
+    // amount is guaranteed to be there
+    // eslint-disable-next-line no-use-before-define
+    amount = assay.coerce(amount);
+    const srcOldRightsAmount = rights.get(location);
+    // eslint-disable-next-line no-use-before-define
+    const srcNewRightsAmount = assay.without(srcOldRightsAmount, amount);
+
+    // ///////////////// commit point //////////////////
+    // All queries above passed with no side effects.
+    // During side effects below, any early exits should be made into
+    // fatal turn aborts.
+
+    rights.set(location, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, location);
+
+    // delete pixel from pixelToPursePayment
+    pixelToPursePayment.delete(pixel);
+  }
+
+  function destroyAll() {
+    rights = makePrivateName(); // reset rights
+  }
+
+  function recordPayment(src, payment, amount, srcNewRightsAmount) {
+    rights.set(src, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, src);
+    rights.init(payment, amount);
+    setLocation(amount, payment);
+  }
+
+  function recordDeposit(
+    srcPayment,
+    srcNewRightsAmount,
+    purse,
+    purseNewRightsAmount,
+  ) {
+    rights.set(srcPayment, srcNewRightsAmount);
+    setLocation(srcNewRightsAmount, srcPayment);
+    rights.set(purse, purseNewRightsAmount);
+    setLocation(purseNewRightsAmount, purse);
+  }
+
+  function recordMint(purse, initialAmount) {
+    rights.init(purse, initialAmount);
+    setLocation(initialAmount, purse);
+  }
+
+  function getAmount(pursePayment) {
+    return rights.get(pursePayment);
+  }
+
+  const mintController = {
+    destroy,
+    destroyAll,
+    recordPayment,
+    recordDeposit,
+    recordMint,
+    getAmount,
+  };
+  return mintController;
+}

--- a/more/pixels/pixelMintController.js
+++ b/more/pixels/pixelMintController.js
@@ -27,7 +27,11 @@ export function makeMintController(assay) {
     // assume length === 1 for now
 
     const pixel = pixelList[0];
-    const location = pixelToPursePayment.get(getString(pixel));
+    const strPixel = getString(pixel);
+    if (!pixelToPursePayment.has(strPixel)) {
+      return;
+    }
+    const location = pixelToPursePayment.get(strPixel);
     // amount is guaranteed to be there
     // eslint-disable-next-line no-use-before-define
     amount = assay.coerce(amount);

--- a/more/pixels/types/pixel.js
+++ b/more/pixels/types/pixel.js
@@ -33,4 +33,14 @@ function isLessThanOrEqual(leftPixel, rightPixel) {
   return leftPixel.x <= rightPixel.x && leftPixel.y <= rightPixel.y;
 }
 
-export { insistWithinBounds, insistPixel, isEqual, isLessThanOrEqual };
+function getString(pixel) {
+  return `x${pixel.x}y${pixel.y}`;
+}
+
+export {
+  insistWithinBounds,
+  insistPixel,
+  isEqual,
+  isLessThanOrEqual,
+  getString,
+};

--- a/more/pixels/types/pixelList.js
+++ b/more/pixels/types/pixelList.js
@@ -88,6 +88,13 @@ function makeWholePixelList(canvasSize) {
   return pixelList;
 }
 
+function insistPixelListEqual(leftPixelList, rightPixelList) {
+  // includes both ways, super inefficient
+  // if pixelLists were ordered, this would be must more efficient
+  insistIncludesPixelList(leftPixelList, rightPixelList);
+  insistIncludesPixelList(rightPixelList, leftPixelList);
+}
+
 export {
   insistPixelList,
   includesPixel,
@@ -96,4 +103,5 @@ export {
   withPixelList,
   withoutPixelList,
   makeWholePixelList,
+  insistPixelListEqual,
 };

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -17,12 +17,10 @@ const contractMintGolden = [
   '=> setup called',
   'starting mintTestAssay',
   'starting mintTestNumber',
-  'alice xfer balance {"label":{"issuer":{},"description":"quatloos"},"quantity":950}',
-  'alice use balance {"label":{"issuer":{},"description":"quatloos"},"quantity":1000}',
-  'payment xfer balance {"label":{"issuer":{},"description":"quatloos"},"quantity":50}',
-  'alice xfer balance {"label":{"issuer":{},"description":"bucks"},"quantity":950}',
-  'alice use balance {"label":{"issuer":{},"description":"bucks"},"quantity":1000}',
-  'payment xfer balance {"label":{"issuer":{},"description":"bucks"},"quantity":50}',
+  'alice balance {"label":{"issuer":{},"description":"quatloos"},"quantity":950}',
+  'payment balance {"label":{"issuer":{},"description":"quatloos"},"quantity":50}',
+  'alice balance {"label":{"issuer":{},"description":"bucks"},"quantity":950}',
+  'payment balance {"label":{"issuer":{},"description":"bucks"},"quantity":50}',
 ];
 
 test('run contractHost Demo --mint with SES', async t => {
@@ -41,10 +39,10 @@ const contractTrivialGolden = [
   '=> setup called',
   'starting trivialContractTest',
   "Does source function trivContract(terms, inviteMaker) {\n      return inviteMaker.make('foo', 8);\n    } match? true",
-  'foo xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":"foo terms","seatIdentity":{},"seatDesc":"foo"}}',
+  'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":"foo terms","seatIdentity":{},"seatDesc":"foo"}}',
   '++ eightP resolved to 8 (should be 8)',
   '++ DONE',
-  'foo xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":null}',
+  'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":null}',
 ];
 
 test('run contractHost Demo --trivial with SES', async t => {
@@ -82,21 +80,17 @@ const contractBobFirstGolden = [
   '=> setup called',
   '++ bob.tradeWell starting',
   '++ alice.acceptInvite starting',
-  'alice invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"fudco"},"quantity":7}],"seatIdentity":{},"seatDesc":"left"}}',
-  'verified invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"fudco"},"quantity":7}],"seatIdentity":{},"seatDesc":"left"}}',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"fudco"},"quantity":7}],"seatIdentity":{},"seatDesc":"left"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"fudco"},"quantity":7}],"seatIdentity":{},"seatDesc":"left"}}',
   'bob escrow wins: {"label":{"issuer":{},"description":"clams"},"quantity":10} refs: null',
   'alice escrow wins: {"label":{"issuer":{},"description":"fudco"},"quantity":7} refs: null',
   '++ bob.tradeWell done',
   '++ bobP.tradeWell done:[[{"label":{"issuer":{},"description":"fudco"},"quantity":7},null],[{"label":{"issuer":{},"description":"clams"},"quantity":10},null]]',
   '++ DONE',
-  'alice money xfer balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
-  'alice money use balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
-  'alice stock xfer balance {"label":{"issuer":{},"description":"fudco"},"quantity":2009}',
-  'alice stock use balance {"label":{"issuer":{},"description":"fudco"},"quantity":2009}',
-  'bob money xfer balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
-  'bob money use balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
-  'bob stock xfer balance {"label":{"issuer":{},"description":"fudco"},"quantity":1996}',
-  'bob stock use balance {"label":{"issuer":{},"description":"fudco"},"quantity":1996}',
+  'alice money balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
+  'alice stock balance {"label":{"issuer":{},"description":"fudco"},"quantity":2009}',
+  'bob money balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
+  'bob stock balance {"label":{"issuer":{},"description":"fudco"},"quantity":1996}',
 ];
 
 test('run contractHost Demo --bob-first with SES', async t => {
@@ -111,27 +105,7 @@ test('run contractHost Demo --bob-first without SES', async t => {
   t.end();
 });
 
-const contractCoveredCallGolden = [
-  '=> setup called',
-  '++ bob.offerAliceOption starting',
-  '++ alice.acceptOptionDirectly starting',
-  'Pretend singularity never happens',
-  'alice invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
-  'verified invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
-  'alice option wins: {"label":{"issuer":{},"description":"yoyodyne"},"quantity":7} refs: null',
-  'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null',
-  '++ bob.offerAliceOption done',
-  '++ bobP.offerAliceOption done:[[{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},null],[{"label":{"issuer":{},"description":"smackers"},"quantity":10},null]]',
-  '++ DONE',
-  'alice money xfer balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
-  'alice money use balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
-  'alice stock xfer balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":2009}',
-  'alice stock use balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":2009}',
-  'bob money xfer balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
-  'bob money use balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
-  'bob stock xfer balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":1996}',
-  'bob stock use balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":1996}',
-];
+const contractCoveredCallGolden = [ '=> setup called', '++ bob.offerAliceOption starting', '++ alice.acceptOptionDirectly starting', 'Pretend singularity never happens', 'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}', 'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}', 'alice option wins: {"label":{"issuer":{},"description":"yoyodyne"},"quantity":7} refs: null', 'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null', '++ bob.offerAliceOption done', '++ bobP.offerAliceOption done:[[{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},null],[{"label":{"issuer":{},"description":"smackers"},"quantity":10},null]]', '++ DONE', 'alice money balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}', 'alice stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":2009}', 'bob money balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}', 'bob stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":1996}' ];
 
 test('run contractHost Demo --covered-call with SES', async t => {
   const dump = await main(true, 'demo/contractHost', ['covered-call']);
@@ -160,22 +134,14 @@ const contractCoveredCallSaleGolden = [
   '++ bob.offerAliceOption done',
   '++ bobP.offerAliceOption done:[[[{"label":{"issuer":{},"description":"wonka"},"quantity":7},null],[{"label":{"issuer":{},"description":"fins"},"quantity":55},null]],[{"label":{"issuer":{},"description":"dough"},"quantity":10},null]]',
   '++ DONE',
-  'alice dough xfer balance {"label":{"issuer":{},"description":"dough"},"quantity":1000}',
-  'alice dough use balance {"label":{"issuer":{},"description":"dough"},"quantity":1000}',
-  'alice stock xfer balance {"label":{"issuer":{},"description":"wonka"},"quantity":2002}',
-  'alice stock use balance {"label":{"issuer":{},"description":"wonka"},"quantity":2002}',
-  'alice fins xfer balance {"label":{"issuer":{},"description":"fins"},"quantity":3055}',
-  'alice fins use balance {"label":{"issuer":{},"description":"fins"},"quantity":3055}',
-  'bob dough xfer balance {"label":{"issuer":{},"description":"dough"},"quantity":1011}',
-  'bob dough use balance {"label":{"issuer":{},"description":"dough"},"quantity":1011}',
-  'bob stock xfer balance {"label":{"issuer":{},"description":"wonka"},"quantity":1996}',
-  'bob stock use balance {"label":{"issuer":{},"description":"wonka"},"quantity":1996}',
-  'fred dough xfer balance {"label":{"issuer":{},"description":"dough"},"quantity":992}',
-  'fred dough use balance {"label":{"issuer":{},"description":"dough"},"quantity":992}',
-  'fred stock xfer balance {"label":{"issuer":{},"description":"wonka"},"quantity":2011}',
-  'fred stock use balance {"label":{"issuer":{},"description":"wonka"},"quantity":2011}',
-  'fred fins xfer balance {"label":{"issuer":{},"description":"fins"},"quantity":2946}',
-  'fred fins use balance {"label":{"issuer":{},"description":"fins"},"quantity":2946}',
+  'alice dough balance {"label":{"issuer":{},"description":"dough"},"quantity":1000}',
+  'alice stock balance {"label":{"issuer":{},"description":"wonka"},"quantity":2002}',
+  'alice fins balance {"label":{"issuer":{},"description":"fins"},"quantity":3055}',
+  'bob dough balance {"label":{"issuer":{},"description":"dough"},"quantity":1011}',
+  'bob stock balance {"label":{"issuer":{},"description":"wonka"},"quantity":1996}',
+  'fred dough balance {"label":{"issuer":{},"description":"dough"},"quantity":992}',
+  'fred stock balance {"label":{"issuer":{},"description":"wonka"},"quantity":2011}',
+  'fred fins balance {"label":{"issuer":{},"description":"fins"},"quantity":2946}',
 ];
 
 test('run contractHost Demo --covered-call-sale with SES', async t => {
@@ -264,9 +230,8 @@ test('run handoff Demo --Two Party handoff', async t => {
 const successfulWithdraw = [
   '=> setup called',
   'starting mintTestPixelListAssay',
-  'alice xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":1},{"x":1,"y":0},{"x":1,"y":1}]}',
-  'alice use balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":0},{"x":1,"y":1}]}',
-  'payment xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0}]}',
+  'alice balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":1},{"x":1,"y":0},{"x":1,"y":1}]}',
+  'payment balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0}]}',
 ];
 
 test('run Pixel Demo mint and withdraw with SES', async t => {
@@ -307,21 +272,17 @@ const contractBobFirstGoldenPixel = [
   '=> setup called',
   '++ bob.tradeWell starting',
   '++ alice.acceptInvite starting',
-  'alice invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]}],"seatIdentity":{},"seatDesc":"left"}}',
-  'verified invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]}],"seatIdentity":{},"seatDesc":"left"}}',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]}],"seatIdentity":{},"seatDesc":"left"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{"label":{"issuer":{},"description":"clams"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]}],"seatIdentity":{},"seatDesc":"left"}}',
   'bob escrow wins: {"label":{"issuer":{},"description":"clams"},"quantity":10} refs: null',
   'alice escrow wins: {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]} refs: null',
   '++ bob.tradeWell done',
   '++ bobP.tradeWell done:[[{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},null],[{"label":{"issuer":{},"description":"clams"},"quantity":10},null]]',
   '++ DONE',
-  'alice money xfer balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
-  'alice money use balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
-  'alice pixels xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
-  'alice pixels use balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
-  'bob money xfer balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
-  'bob money use balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
-  'bob pixels xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
-  'bob pixels use balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
+  'alice money balance {"label":{"issuer":{},"description":"clams"},"quantity":990}',
+  'alice pixels balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
+  'bob money balance {"label":{"issuer":{},"description":"clams"},"quantity":1011}',
+  'bob pixels balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
 ];
 
 test('run Pixel Demo --bob-first with SES', async t => {
@@ -341,21 +302,17 @@ const contractCoveredCallGoldenPixel = [
   '++ bob.offerAliceOption starting',
   '++ alice.acceptOptionDirectly starting',
   'Pretend singularity never happens',
-  'alice invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
-  'verified invite xfer balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
   'alice option wins: {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]} refs: null',
   'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null',
   '++ bob.offerAliceOption done',
   '++ bobP.offerAliceOption done:[[{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},null],[{"label":{"issuer":{},"description":"smackers"},"quantity":10},null]]',
   '++ DONE',
-  'alice money xfer balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
-  'alice money use balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
-  'alice pixel xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
-  'alice pixel use balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
-  'bob money xfer balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
-  'bob money use balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
-  'bob pixel xfer balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
-  'bob pixel use balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
+  'alice money balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
+  'alice pixel balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":0,"y":0},{"x":0,"y":1},{"x":1,"y":1}]}',
+  'bob money balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
+  'bob pixel balance {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":0}]}',
 ];
 
 test('run Pixel Demo --covered-call with SES', async t => {

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -105,7 +105,23 @@ test('run contractHost Demo --bob-first without SES', async t => {
   t.end();
 });
 
-const contractCoveredCallGolden = [ '=> setup called', '++ bob.offerAliceOption starting', '++ alice.acceptOptionDirectly starting', 'Pretend singularity never happens', 'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}', 'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}', 'alice option wins: {"label":{"issuer":{},"description":"yoyodyne"},"quantity":7} refs: null', 'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null', '++ bob.offerAliceOption done', '++ bobP.offerAliceOption done:[[{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},null],[{"label":{"issuer":{},"description":"smackers"},"quantity":10},null]]', '++ DONE', 'alice money balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}', 'alice stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":2009}', 'bob money balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}', 'bob stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":1996}' ];
+const contractCoveredCallGolden = [
+  '=> setup called',
+  '++ bob.offerAliceOption starting',
+  '++ alice.acceptOptionDirectly starting',
+  'Pretend singularity never happens',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'alice option wins: {"label":{"issuer":{},"description":"yoyodyne"},"quantity":7} refs: null',
+  'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null',
+  '++ bob.offerAliceOption done',
+  '++ bobP.offerAliceOption done:[[{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},null],[{"label":{"issuer":{},"description":"smackers"},"quantity":10},null]]',
+  '++ DONE',
+  'alice money balance {"label":{"issuer":{},"description":"smackers"},"quantity":990}',
+  'alice stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":2009}',
+  'bob money balance {"label":{"issuer":{},"description":"smackers"},"quantity":1011}',
+  'bob stock balance {"label":{"issuer":{},"description":"yoyodyne"},"quantity":1996}',
+];
 
 test('run contractHost Demo --covered-call with SES', async t => {
   const dump = await main(true, 'demo/contractHost', ['covered-call']);

--- a/test/demo/test-gallery-demo.js
+++ b/test/demo/test-gallery-demo.js
@@ -58,7 +58,7 @@ test('run gallery demo aliceChangesColor without SES', async t => {
 
 const expectedAliceSendsOnlyUseRightLog = [
   '=> setup called',
-  'aliceSendsOnlyUseRight',
+  'starting aliceSendsOnlyUseRight',
   'alice is made',
   'starting testAliceSendsOnlyUseRight',
   '++ alice.doOnlySendUseRight starting',
@@ -79,5 +79,27 @@ test('run gallery demo aliceSendsOnlyUseRight with SES', async t => {
 test('run gallery demo aliceSendsOnlyUseRight without SES', async t => {
   const dump = await main(false, 'demo/gallery', ['aliceSendsOnlyUseRight']);
   t.deepEquals(dump.log, expectedAliceSendsOnlyUseRightLog);
+  t.end();
+});
+
+const expectedGalleryRevokesLog = [
+  '=> setup called',
+  'starting galleryRevokes',
+  'starting testGalleryRevokes',
+  '++ alice.doTapFaucetAndStore starting',
+  '++ alice.checkAfterRevoked starting',
+  'amount quantity should be an array of length 0: 0',
+  'successfully threw Error: no use rights present',
+];
+
+test('run gallery demo galleryRevokes with SES', async t => {
+  const dump = await main(true, 'demo/gallery', ['galleryRevokes']);
+  t.deepEquals(dump.log, expectedGalleryRevokesLog);
+  t.end();
+});
+
+test('run gallery demo galleryRevokes without SES', async t => {
+  const dump = await main(false, 'demo/gallery', ['galleryRevokes']);
+  t.deepEquals(dump.log, expectedGalleryRevokesLog);
   t.end();
 });

--- a/test/demo/test-gallery-demo.js
+++ b/test/demo/test-gallery-demo.js
@@ -55,3 +55,29 @@ test('run gallery demo aliceChangesColor without SES', async t => {
   t.deepEquals(dump.log, expectedAliceChangesColorLog);
   t.end();
 });
+
+const expectedAliceSendsOnlyUseRightLog = [
+  '=> setup called',
+  'aliceSendsOnlyUseRight',
+  'alice is made',
+  'starting testAliceSendsOnlyUseRight',
+  '++ alice.doOnlySendUseRight starting',
+  'tapped Faucet',
+  'pixel x:1, y:4 has original color #D3D3D3',
+  '++ bob.receiveUseRight starting',
+  "pixel x:1, y:4 changed to bob's color #B695C0",
+  "pixel x:1, y:4 changed to alice's color #9FBF95",
+  'bob was unable to color: Error: no use rights present',
+];
+
+test('run gallery demo aliceSendsOnlyUseRight with SES', async t => {
+  const dump = await main(true, 'demo/gallery', ['aliceSendsOnlyUseRight']);
+  t.deepEquals(dump.log, expectedAliceSendsOnlyUseRightLog);
+  t.end();
+});
+
+test('run gallery demo aliceSendsOnlyUseRight without SES', async t => {
+  const dump = await main(false, 'demo/gallery', ['aliceSendsOnlyUseRight']);
+  t.deepEquals(dump.log, expectedAliceSendsOnlyUseRightLog);
+  t.end();
+});

--- a/test/demo/test-gallery-demo.js
+++ b/test/demo/test-gallery-demo.js
@@ -1,0 +1,57 @@
+import { test } from 'tape-promise/tape';
+import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+
+async function main(withSES, basedir, argv) {
+  const config = await loadBasedir(basedir);
+  const ldSrcPath = require.resolve(
+    '@agoric/swingset-vat/src/devices/loopbox-src',
+  );
+  config.devices = [['loopbox', ldSrcPath, {}]];
+
+  const controller = await buildVatController(config, withSES, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+const expectedTapFaucetLog = [
+  '=> setup called',
+  'starting tapFaucet',
+  'alice is made',
+  'starting testTapFaucet',
+  '++ alice.doTapFaucet starting',
+  'pixel from faucet balance {"label":{"issuer":{},"description":"pixels"},"quantity":[{"x":1,"y":4}]}',
+];
+
+test('run gallery demo tapFaucet with SES', async t => {
+  const dump = await main(true, 'demo/gallery', ['tapFaucet']);
+  t.deepEquals(dump.log, expectedTapFaucetLog);
+  t.end();
+});
+
+test('run gallery demo tapFaucet without SES', async t => {
+  const dump = await main(false, 'demo/gallery', ['tapFaucet']);
+  t.deepEquals(dump.log, expectedTapFaucetLog);
+  t.end();
+});
+
+const expectedAliceChangesColorLog = [
+  '=> setup called',
+  'starting aliceChangesColor',
+  'alice is made',
+  'starting testAliceChangesColor',
+  '++ alice.doChangeColor starting',
+  'tapped Faucet',
+  'current color #000000',
+];
+
+test('run gallery demo aliceChangesColor with SES', async t => {
+  const dump = await main(true, 'demo/gallery', ['aliceChangesColor']);
+  t.deepEquals(dump.log, expectedAliceChangesColorLog);
+  t.end();
+});
+
+test('run gallery demo aliceChangesColor without SES', async t => {
+  const dump = await main(false, 'demo/gallery', ['aliceChangesColor']);
+  t.deepEquals(dump.log, expectedAliceChangesColorLog);
+  t.end();
+});

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -209,3 +209,44 @@ test('The Gallery revokes the right to transfer the pixel or color with it', asy
 
   t.end();
 });
+
+test('getDistance', t => {
+  const { adminFacet } = makeGallery();
+  const { getDistance } = adminFacet;
+  t.strictEqual(getDistance({ x: 0, y: 1 }, { x: 0, y: 1 }), 0);
+  t.strictEqual(getDistance({ x: 2, y: 1 }, { x: 0, y: 1 }), 2);
+  t.strictEqual(getDistance({ x: 2, y: 3 }, { x: 0, y: 1 }), 2);
+  t.strictEqual(getDistance({ x: 0, y: 1 }, { x: 4, y: 1 }), 4);
+  t.strictEqual(getDistance({ x: 2, y: 2 }, { x: 0, y: 7 }), 5);
+  t.end();
+});
+
+test('getDistanceFromCenter', t => {
+  const { adminFacet } = makeGallery();
+  // default canvasSize is 10
+  const { getDistanceFromCenter } = adminFacet;
+  t.strictEqual(getDistanceFromCenter({ x: 0, y: 1 }), 6);
+  t.strictEqual(getDistanceFromCenter({ x: 2, y: 1 }), 5);
+  t.strictEqual(getDistanceFromCenter({ x: 2, y: 3 }), 3);
+  t.strictEqual(getDistanceFromCenter({ x: 4, y: 1 }), 4);
+  t.strictEqual(getDistanceFromCenter({ x: 0, y: 7 }), 5);
+  t.strictEqual(getDistanceFromCenter({ x: 5, y: 5 }), 0);
+  t.end();
+});
+
+test('pricePixel', t => {
+  const { adminFacet, userFacet } = makeGallery();
+  // default canvasSize is 10
+  const { pricePixel } = adminFacet;
+  const { getIssuers } = userFacet;
+  const { dustIssuer } = getIssuers();
+  const dustAssay = dustIssuer.getAssay();
+
+  t.deepEqual(pricePixel({ x: 0, y: 1 }), dustAssay.make(4));
+  t.deepEqual(pricePixel({ x: 2, y: 1 }), dustAssay.make(5));
+  t.deepEqual(pricePixel({ x: 2, y: 3 }), dustAssay.make(7));
+  t.deepEqual(pricePixel({ x: 4, y: 1 }), dustAssay.make(6));
+  t.deepEqual(pricePixel({ x: 0, y: 7 }), dustAssay.make(5));
+  t.deepEqual(pricePixel({ x: 5, y: 5 }), dustAssay.make(10));
+  t.end();
+});

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -1,6 +1,8 @@
 import { test } from 'tape-promise/tape';
 
-import { userFacet } from '../../../more/pixels/gallery';
+import { userFacet, testFacet } from '../../../more/pixels/gallery';
+
+import { insistPixelList } from '../../../more/pixels/types/pixelList';
 
 const {
   changeColor,
@@ -11,51 +13,177 @@ const {
   getIssuers,
 } = userFacet;
 
+const { revokePixel, getCanvasSize } = testFacet;
+
 const { pixelIssuer, useRightIssuer, transferRightIssuer } = getIssuers();
 
-test.only('the user changes the color of a pixel', t => {
-  // user actions
+test('tapFaucet', t => {
   const pixelPayment = tapFaucet();
-  const exclusivePixelPayment = pixelIssuer.getExclusive(pixelPayment);
-  const { transferRightPayment, useRightPayment } = transformToTransferAndUse(
-    exclusivePixelPayment,
-  );
-  const exclusiveTransferRightPayment = transferRightIssuer.getExclusive(
-    transferRightPayment,
-  );
-  const exclusiveUseRightPayment = useRightIssuer.getExclusive(useRightPayment);
-  changeColor(exclusiveUseRightPayment, '#00000');
-
-  const rawPixel = pixelPayment.getBalance().quantity()[0];
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  const amount = pixelPayment.getBalance();
+  const pixelAssay = pixelIssuer.getAssay();
+  const quantity = pixelAssay.quantity(amount);
+  t.doesNotThrow(() => insistPixelList(quantity, getCanvasSize()));
   t.end();
 });
 
+test('get exclusive pixel payment from faucet', t => {
+  const payment = tapFaucet();
+  pixelIssuer.getExclusiveAll(payment).then(pixelPayment => {
+    const amount = pixelPayment.getBalance();
+    const pixelAssay = pixelIssuer.getAssay();
+    const quantity = pixelAssay.quantity(amount);
+    t.doesNotThrow(() => insistPixelList(quantity, getCanvasSize()));
+    t.end();
+  });
+});
 
+test('the user changes the color of a pixel', async t => {
+  // user actions
+  const pixelPayment = tapFaucet();
 
-test.only('The user allows someone else to change the color but not the right to transfer the right to change the color', t => {
-  // setup
+  const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
+  const { useRightPayment } = await transformToTransferAndUse(
+    exclusivePixelPayment,
+  );
+  const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
+    useRightPayment,
+  );
+  const useRightAssay = exclusiveUseRightPayment.getIssuer().getAssay();
+
+  const rawPixel = useRightAssay.quantity(
+    exclusiveUseRightPayment.getBalance(),
+  )[0];
+  await changeColor(exclusiveUseRightPayment, '#000000');
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#000000');
+  t.end();
+});
+
+// The user gives away the right to change the color (but not transfer the right to transfer the color) and guarantees that the right to change the color is exclusive. Even the original user cannot change the color unless they transfer the pixel back to themselves.
+test('The user allows someone else to change the color but not the right to transfer the right to change the color', async t => {
+  // user actions
+  const pixelPayment = tapFaucet();
+
+  const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
+  const {
+    useRightPayment,
+    transferRightPayment,
+  } = await transformToTransferAndUse(exclusivePixelPayment);
+  const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
+    useRightPayment,
+  );
+  const exclusiveTransferRightPayment = await transferRightIssuer.getExclusiveAll(
+    transferRightPayment,
+  );
+  const useRightAssay = exclusiveUseRightPayment.getIssuer().getAssay();
+
+  const rawPixel = useRightAssay.quantity(
+    exclusiveUseRightPayment.getBalance(),
+  )[0];
+
+  // TODO: send to other vat
+  // other user below
+  const otherUserPurse = useRightIssuer.makeEmptyPurse();
+  const otherUserExclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
+    exclusiveUseRightPayment,
+  );
+  await otherUserPurse.depositAll(otherUserExclusiveUseRightPayment);
+
+  // ok until this line
+  const payment = await otherUserPurse.withdrawAll();
+
+  const exclusivePayment = await useRightIssuer.getExclusiveAll(payment);
+
+  await changeColor(exclusivePayment, '#00000');
+
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+
+  // original user transforms the transfer right into a pixel to get
+  // the color right back
+  const pixelPayment2 = await transformToPixel(exclusiveTransferRightPayment);
+  const exclusivePixelPayment2 = await pixelIssuer.getExclusiveAll(
+    pixelPayment2,
+  );
+  const { useRightPayment: useRightPayment2 } = await transformToTransferAndUse(
+    exclusivePixelPayment2,
+  );
+  const exclusiveUseRightPayment2 = await useRightIssuer.getExclusiveAll(
+    useRightPayment2,
+  );
+  await changeColor(exclusiveUseRightPayment2, '#FFFFFF');
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#FFFFFF');
+
+  // other user cannot color
+  t.rejects(changeColor(exclusivePayment, '#00000'));
+  t.end();
+});
+
+test('The user gives away their right to the pixel (right to transfer color rights) permanently', async t => {
   const pixelPurse = pixelIssuer.makeEmptyPurse();
-  const useRightPurse = useRightIssuer.makeEmptyPurse();
-  const transferRightPurse = transferRightIssuer.makeEmptyPurse();
 
   // user actions
   const pixelPayment = tapFaucet();
-  const exclusivePixelPayment = pixelIssuer.getExclusive(pixelPayment);
-  const { transferRightPayment, useRightPayment } = transformToTransferAndUse(
-    exclusivePixelPayment,
+  const pixelAssay = pixelIssuer.getAssay();
+  const rawPixel = pixelAssay.quantity(pixelPayment.getBalance())[0];
+  const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
+  await pixelPurse.depositAll(exclusivePixelPayment);
+
+  const newPayment = await pixelPurse.withdrawAll();
+
+  // TODO: send over vat to other user
+
+  const exclPaymentNewUser = await pixelIssuer.getExclusiveAll(newPayment);
+
+  const { useRightPayment } = await transformToTransferAndUse(
+    exclPaymentNewUser,
   );
-  const exclusiveTransferRightPayment = transferRightIssuer.getExclusive(
+  const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
+    useRightPayment,
+  );
+
+  await changeColor(exclusiveUseRightPayment, '#00000');
+
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+
+  t.rejects(transformToTransferAndUse(newPayment));
+  t.end();
+});
+
+test('The Gallery revokes the right to transfer the pixel or color with it', async t => {
+
+  // user actions
+  const pixelPayment = tapFaucet();
+  const pixelAssay = pixelIssuer.getAssay();
+  const rawPixel = pixelAssay.quantity(pixelPayment.getBalance())[0];
+  const originalColor = getColor(rawPixel.x, rawPixel.y);
+  const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
+
+  const {
+    useRightPayment,
+    transferRightPayment,
+  } = await transformToTransferAndUse(exclusivePixelPayment);
+  const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
+    useRightPayment,
+  );
+  const exclusiveTransferRightPayment = await transferRightIssuer.getExclusiveAll(
     transferRightPayment,
   );
-  const exclusiveUseRightPayment = useRightIssuer.getExclusive(useRightPayment);
-  
-  const otherUserPurse = useRightIssuer.makeEmptyPurse();
-  otherUserPurse.depositAll(exclusiveUseRightPayment);
 
-  changeColor(exclusiveUseRightPayment, '#00000');
+  // Gallery revokes
+  revokePixel(rawPixel);
 
-  const rawPixel = pixelPayment.getBalance().quantity()[0];
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  // TODO: send over vat to other user
+
+  t.rejects(changeColor(exclusiveUseRightPayment, '#00000'));
+  // other user tries to get exclusive on the transfer right that was sent to
+  // them.
+  const otherUserTransferRightPayment = await transferRightIssuer.getExclusiveAll(
+    exclusiveTransferRightPayment,
+  );
+  // this doesn't error but is empty
+  const balance = otherUserTransferRightPayment.getBalance();
+
+  t.deepEqual(balance.quantity, []);
+  t.strictEqual(getColor(rawPixel.x, rawPixel.y), originalColor);
+
   t.end();
 });

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -127,6 +127,7 @@ test('The user gives away their right to the pixel (right to transfer color righ
   // setup
   const { userFacet } = makeGallery();
   const { pixelIssuer, useRightIssuer } = userFacet.getIssuers();
+  const useRightAssay = useRightIssuer.getAssay();
 
   const pixelPurse = pixelIssuer.makeEmptyPurse();
 
@@ -154,7 +155,11 @@ test('The user gives away their right to the pixel (right to transfer color righ
 
   t.equal(userFacet.getColor(rawPixel.x, rawPixel.y), '#00000');
 
-  t.rejects(userFacet.transformToTransferAndUse(newPayment));
+  const {
+    useRightPayment: useRightPayment2,
+  } = await userFacet.transformToTransferAndUse(newPayment);
+  const amount = useRightPayment2.getBalance();
+  t.true(useRightAssay.isEmpty(amount));
   t.end();
 });
 

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -1,48 +1,43 @@
 import { test } from 'tape-promise/tape';
 
-import { userFacet, testFacet } from '../../../more/pixels/gallery';
+import { makeGallery } from '../../../more/pixels/gallery';
 
 import { insistPixelList } from '../../../more/pixels/types/pixelList';
 
-const {
-  changeColor,
-  getColor,
-  tapFaucet,
-  transformToTransferAndUse,
-  transformToPixel,
-  getIssuers,
-} = userFacet;
-
-const { revokePixel, getCanvasSize } = testFacet;
-
-const { pixelIssuer, useRightIssuer, transferRightIssuer } = getIssuers();
-
 test('tapFaucet', t => {
-  const pixelPayment = tapFaucet();
+  const { userFacet } = makeGallery();
+  const { pixelIssuer } = userFacet.getIssuers();
+  const pixelPayment = userFacet.tapFaucet();
   const amount = pixelPayment.getBalance();
   const pixelAssay = pixelIssuer.getAssay();
   const quantity = pixelAssay.quantity(amount);
-  t.doesNotThrow(() => insistPixelList(quantity, getCanvasSize()));
+  t.doesNotThrow(() => insistPixelList(quantity, userFacet.getCanvasSize()));
   t.end();
 });
 
 test('get exclusive pixel payment from faucet', t => {
-  const payment = tapFaucet();
+  const { userFacet } = makeGallery();
+  const payment = userFacet.tapFaucet();
+  const { pixelIssuer } = userFacet.getIssuers();
   pixelIssuer.getExclusiveAll(payment).then(pixelPayment => {
     const amount = pixelPayment.getBalance();
     const pixelAssay = pixelIssuer.getAssay();
     const quantity = pixelAssay.quantity(amount);
-    t.doesNotThrow(() => insistPixelList(quantity, getCanvasSize()));
+    t.doesNotThrow(() => insistPixelList(quantity, userFacet.getCanvasSize()));
     t.end();
   });
 });
 
 test('the user changes the color of a pixel', async t => {
+  // setup
+  const { userFacet } = makeGallery();
+  const { pixelIssuer, useRightIssuer } = userFacet.getIssuers();
+
   // user actions
-  const pixelPayment = tapFaucet();
+  const pixelPayment = userFacet.tapFaucet();
 
   const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
-  const { useRightPayment } = await transformToTransferAndUse(
+  const { useRightPayment } = await userFacet.transformToTransferAndUse(
     exclusivePixelPayment,
   );
   const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
@@ -53,21 +48,29 @@ test('the user changes the color of a pixel', async t => {
   const rawPixel = useRightAssay.quantity(
     exclusiveUseRightPayment.getBalance(),
   )[0];
-  await changeColor(exclusiveUseRightPayment, '#000000');
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#000000');
+  await userFacet.changeColor(exclusiveUseRightPayment, '#000000');
+  t.equal(userFacet.getColor(rawPixel.x, rawPixel.y), '#000000');
   t.end();
 });
 
 // The user gives away the right to change the color (but not transfer the right to transfer the color) and guarantees that the right to change the color is exclusive. Even the original user cannot change the color unless they transfer the pixel back to themselves.
 test('The user allows someone else to change the color but not the right to transfer the right to change the color', async t => {
+  // setup
+  const { userFacet } = makeGallery();
+  const {
+    pixelIssuer,
+    useRightIssuer,
+    transferRightIssuer,
+  } = userFacet.getIssuers();
+
   // user actions
-  const pixelPayment = tapFaucet();
+  const pixelPayment = userFacet.tapFaucet();
 
   const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
   const {
     useRightPayment,
     transferRightPayment,
-  } = await transformToTransferAndUse(exclusivePixelPayment);
+  } = await userFacet.transformToTransferAndUse(exclusivePixelPayment);
   const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
     useRightPayment,
   );
@@ -93,35 +96,41 @@ test('The user allows someone else to change the color but not the right to tran
 
   const exclusivePayment = await useRightIssuer.getExclusiveAll(payment);
 
-  await changeColor(exclusivePayment, '#00000');
+  await userFacet.changeColor(exclusivePayment, '#00000');
 
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  t.equal(userFacet.getColor(rawPixel.x, rawPixel.y), '#00000');
 
   // original user transforms the transfer right into a pixel to get
   // the color right back
-  const pixelPayment2 = await transformToPixel(exclusiveTransferRightPayment);
+  const pixelPayment2 = await userFacet.transformToPixel(
+    exclusiveTransferRightPayment,
+  );
   const exclusivePixelPayment2 = await pixelIssuer.getExclusiveAll(
     pixelPayment2,
   );
-  const { useRightPayment: useRightPayment2 } = await transformToTransferAndUse(
-    exclusivePixelPayment2,
-  );
+  const {
+    useRightPayment: useRightPayment2,
+  } = await userFacet.transformToTransferAndUse(exclusivePixelPayment2);
   const exclusiveUseRightPayment2 = await useRightIssuer.getExclusiveAll(
     useRightPayment2,
   );
-  await changeColor(exclusiveUseRightPayment2, '#FFFFFF');
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#FFFFFF');
+  await userFacet.changeColor(exclusiveUseRightPayment2, '#FFFFFF');
+  t.equal(userFacet.getColor(rawPixel.x, rawPixel.y), '#FFFFFF');
 
   // other user cannot color
-  t.rejects(changeColor(exclusivePayment, '#00000'));
+  t.rejects(userFacet.changeColor(exclusivePayment, '#00000'));
   t.end();
 });
 
 test('The user gives away their right to the pixel (right to transfer color rights) permanently', async t => {
+  // setup
+  const { userFacet } = makeGallery();
+  const { pixelIssuer, useRightIssuer } = userFacet.getIssuers();
+
   const pixelPurse = pixelIssuer.makeEmptyPurse();
 
   // user actions
-  const pixelPayment = tapFaucet();
+  const pixelPayment = userFacet.tapFaucet();
   const pixelAssay = pixelIssuer.getAssay();
   const rawPixel = pixelAssay.quantity(pixelPayment.getBalance())[0];
   const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
@@ -133,34 +142,41 @@ test('The user gives away their right to the pixel (right to transfer color righ
 
   const exclPaymentNewUser = await pixelIssuer.getExclusiveAll(newPayment);
 
-  const { useRightPayment } = await transformToTransferAndUse(
+  const { useRightPayment } = await userFacet.transformToTransferAndUse(
     exclPaymentNewUser,
   );
   const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
     useRightPayment,
   );
 
-  await changeColor(exclusiveUseRightPayment, '#00000');
+  await userFacet.changeColor(exclusiveUseRightPayment, '#00000');
 
-  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  t.equal(userFacet.getColor(rawPixel.x, rawPixel.y), '#00000');
 
-  t.rejects(transformToTransferAndUse(newPayment));
+  t.rejects(userFacet.transformToTransferAndUse(newPayment));
   t.end();
 });
 
 test('The Gallery revokes the right to transfer the pixel or color with it', async t => {
+  // setup
+  const { userFacet, adminFacet } = makeGallery();
+  const {
+    pixelIssuer,
+    useRightIssuer,
+    transferRightIssuer,
+  } = userFacet.getIssuers();
 
   // user actions
-  const pixelPayment = tapFaucet();
+  const pixelPayment = userFacet.tapFaucet();
   const pixelAssay = pixelIssuer.getAssay();
   const rawPixel = pixelAssay.quantity(pixelPayment.getBalance())[0];
-  const originalColor = getColor(rawPixel.x, rawPixel.y);
+  const originalColor = userFacet.getColor(rawPixel.x, rawPixel.y);
   const exclusivePixelPayment = await pixelIssuer.getExclusiveAll(pixelPayment);
 
   const {
     useRightPayment,
     transferRightPayment,
-  } = await transformToTransferAndUse(exclusivePixelPayment);
+  } = await userFacet.transformToTransferAndUse(exclusivePixelPayment);
   const exclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
     useRightPayment,
   );
@@ -169,11 +185,11 @@ test('The Gallery revokes the right to transfer the pixel or color with it', asy
   );
 
   // Gallery revokes
-  revokePixel(rawPixel);
+  adminFacet.revokePixel(rawPixel);
 
   // TODO: send over vat to other user
 
-  t.rejects(changeColor(exclusiveUseRightPayment, '#00000'));
+  t.rejects(userFacet.changeColor(exclusiveUseRightPayment, '#00000'));
   // other user tries to get exclusive on the transfer right that was sent to
   // them.
   const otherUserTransferRightPayment = await transferRightIssuer.getExclusiveAll(
@@ -183,7 +199,7 @@ test('The Gallery revokes the right to transfer the pixel or color with it', asy
   const balance = otherUserTransferRightPayment.getBalance();
 
   t.deepEqual(balance.quantity, []);
-  t.strictEqual(getColor(rawPixel.x, rawPixel.y), originalColor);
+  t.strictEqual(userFacet.getColor(rawPixel.x, rawPixel.y), originalColor);
 
   t.end();
 });

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -1,0 +1,61 @@
+import { test } from 'tape-promise/tape';
+
+import { userFacet } from '../../../more/pixels/gallery';
+
+const {
+  changeColor,
+  getColor,
+  tapFaucet,
+  transformToTransferAndUse,
+  transformToPixel,
+  getIssuers,
+} = userFacet;
+
+const { pixelIssuer, useRightIssuer, transferRightIssuer } = getIssuers();
+
+test.only('the user changes the color of a pixel', t => {
+  // user actions
+  const pixelPayment = tapFaucet();
+  const exclusivePixelPayment = pixelIssuer.getExclusive(pixelPayment);
+  const { transferRightPayment, useRightPayment } = transformToTransferAndUse(
+    exclusivePixelPayment,
+  );
+  const exclusiveTransferRightPayment = transferRightIssuer.getExclusive(
+    transferRightPayment,
+  );
+  const exclusiveUseRightPayment = useRightIssuer.getExclusive(useRightPayment);
+  changeColor(exclusiveUseRightPayment, '#00000');
+
+  const rawPixel = pixelPayment.getBalance().quantity()[0];
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  t.end();
+});
+
+
+
+test.only('The user allows someone else to change the color but not the right to transfer the right to change the color', t => {
+  // setup
+  const pixelPurse = pixelIssuer.makeEmptyPurse();
+  const useRightPurse = useRightIssuer.makeEmptyPurse();
+  const transferRightPurse = transferRightIssuer.makeEmptyPurse();
+
+  // user actions
+  const pixelPayment = tapFaucet();
+  const exclusivePixelPayment = pixelIssuer.getExclusive(pixelPayment);
+  const { transferRightPayment, useRightPayment } = transformToTransferAndUse(
+    exclusivePixelPayment,
+  );
+  const exclusiveTransferRightPayment = transferRightIssuer.getExclusive(
+    transferRightPayment,
+  );
+  const exclusiveUseRightPayment = useRightIssuer.getExclusive(useRightPayment);
+  
+  const otherUserPurse = useRightIssuer.makeEmptyPurse();
+  otherUserPurse.depositAll(exclusiveUseRightPayment);
+
+  changeColor(exclusiveUseRightPayment, '#00000');
+
+  const rawPixel = pixelPayment.getBalance().quantity()[0];
+  t.equal(getColor(rawPixel.x, rawPixel.y), '#00000');
+  t.end();
+});

--- a/test/more/pixels/test-gallery.js
+++ b/test/more/pixels/test-gallery.js
@@ -79,19 +79,20 @@ test('The user allows someone else to change the color but not the right to tran
   );
   const useRightAssay = exclusiveUseRightPayment.getIssuer().getAssay();
 
+  // first user stores the pixel location info
   const rawPixel = useRightAssay.quantity(
     exclusiveUseRightPayment.getBalance(),
   )[0];
 
   // TODO: send to other vat
   // other user below
+  // other user puts the useRight in their purse, changes color
   const otherUserPurse = useRightIssuer.makeEmptyPurse();
   const otherUserExclusiveUseRightPayment = await useRightIssuer.getExclusiveAll(
     exclusiveUseRightPayment,
   );
   await otherUserPurse.depositAll(otherUserExclusiveUseRightPayment);
 
-  // ok until this line
   const payment = await otherUserPurse.withdrawAll();
 
   const exclusivePayment = await useRightIssuer.getExclusiveAll(payment);


### PR DESCRIPTION
## Description
This PR adds the following pixel demo functionality:
* The ability to revoke rights (held by a new abstraction, a `mintController`, which also controls the rights WeakMap in general)
* The ability to split an assay into use and transfer rights that are of themselves, full ERTP erights, and merge them back again

## Changes to ERTP
* XferRights and useRights aren't hardcoded into makeMint. Instead, there is only one rights WeakMap. All previous ERTP tests pass with this change, meaning that useRights was not being used yet in our tests. In this PR, the base right (a pixelList) is actually a compound right that can be split up by the Gallery upon request into use and transfer rights. Both are full erights themselves, so they act in all the usual ways, but they can also be merged back to together: upon receipt of a transferRightPayment, the user can send it to the Gallery and ask for a full pixel back again. 
* The Gallery needed the ability to revoke rights, which were closely held in the weakMap in `makeMint`. In order to get access, I introduced a `'mintController` which holds the weakMap and can also remove amounts from the weakMap to destroy certain erights. (If the weakMap is replaced, all erights that were produced by the mint are destroyed.)

## Pixel Demo
More info on the Gallery pixel demo in particular at demo/gallery/README.md

## Future TODOs
* While the splitting of the use and transfer rights in the pixel demo works fine with ERTP, we will want to merge that functionality into `issuer.js` in a reusable way. We may have to build a few examples to find the common elements. Excitingly, this should allow us to also create compound erights building up: rectangle erights built out of pixels, synthetic stocks, etc. 

## Test
`npm test`
New tests added in:
  test/demo/test-gallery-demo.js 
  test/more/pixels/test-gallery.js
