### PR TITLE
Requeue a pixel if colored

### DIFF
--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -329,6 +329,9 @@ export function makeGallery(
     getDistance,
     getDistanceFromCenter,
     pricePixelAmount,
+    getLRUQueue() {
+      return lruQueue.getState();
+    },
   };
 
   const readFacet = {

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -205,6 +205,7 @@ export function makeGallery(
       for (let i = 0; i < pixelList.length; i += 1) {
         const pixel = pixelList[i];
         setPixelState(pixel, newColor);
+        lruQueue.requeue(pixel);
       }
       return pixelAmount;
     });

--- a/more/pixels/lruQueue.js
+++ b/more/pixels/lruQueue.js
@@ -103,7 +103,18 @@ export function makeLruQueue() {
     }
   }
 
-  const lruQueue = harden({ popToTail, requeue });
+  function getState() {
+    const result = [];
+    let start = head;
+    result.push(start.contents);
+    while (start.next) {
+      result.push(start.next.contents);
+      start = start.next;
+    }
+    return result;
+  }
+
+  const lruQueue = harden({ popToTail, requeue, getState });
   const lruQueueBuilder = harden({ push, resortArbitrarily, isEmpty });
 
   return harden({ lruQueue, lruQueueBuilder });

--- a/test/more/pixels/test-lruQueue.js
+++ b/test/more/pixels/test-lruQueue.js
@@ -94,3 +94,21 @@ test('LRU reorder', t => {
 
   t.end();
 });
+
+test('LRU getState', t => {
+  const { lruQueue, lruQueueBuilder } = makeLruQueue();
+  for (let i = 0; i < 2; i += 1) {
+    for (let j = 0; j < 2; j += 1) {
+      lruQueueBuilder.push({ x: i, y: j });
+    }
+  }
+  const currentState = lruQueue.getState();
+  t.deepEqual(currentState, [
+    { x: 0, y: 0 },
+    { x: 0, y: 1 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ]);
+
+  t.end();
+});


### PR DESCRIPTION
This PR adds a call to lruQueue.requeue() with the rawPixel that was colored. 

It also adds a test, which needs a way to know the current state of the LRUQueue is. I had to create a getState method on the lruQueue that just creates an array of the contents of the queue. @Chris-Hibbert  let me know if this looks like what you would want the lruQueue to have. 