### PR TITLE
gallery: generalise color-bleed fix with padStart

### DIFF
--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -27,7 +27,10 @@ export function makeGallery(
   canvasSize = 10,
 ) {
   function getRandomColor(fraction, num) {
-    // TODO: actually getRandomColor in a deterministic way
+    // This is a linear-feedback shift register with computed startState
+    // and number of iterations.  Thus, it is totally deterministic, but
+    // at least looks a little random.
+
     /* eslint-disable no-bitwise */
     const startState = Math.floor(fraction * 0xffffffff) ^ 0xdeadbeef;
     let lfsr = startState;
@@ -38,11 +41,11 @@ export function makeGallery(
     }
     /* eslint-enable no-bitwise */
 
-    const rand = (Math.floor(lfsr) % 0x7fffff) + 0x800000;
-    let randomColor = `#${rand.toString(16)}`;
-    if (randomColor.length === 6) {
-      randomColor = `${randomColor}0`;
-    }
+    // lfsr may be negative, so we make it start at 0.
+    const rand = (Math.floor(lfsr) % 0x800000) + 0x7fffff;
+
+    // Need to pad the beginning of the string with zeros.
+    const randomColor = `#${rand.toString(16).padStart(6, '0')}`;
     const isHexColor = color => /^#[0-9A-F]{6}$/i.test(color);
     if (!isHexColor(randomColor)) {
       throw new Error(`color ${randomColor} is not a valid color`);

--- a/test/demo/test-gallery-demo.js
+++ b/test/demo/test-gallery-demo.js
@@ -64,7 +64,7 @@ const expectedAliceSendsOnlyUseRightLog = [
   'starting testAliceSendsOnlyUseRight',
   '++ alice.doOnlySendUseRight starting',
   'tapped Faucet',
-  'pixel x:1, y:4 has original color #a90490',
+  'pixel x:1, y:4 has original color #a903be',
   '++ bob.receiveUseRight starting',
   "pixel x:1, y:4 changed to bob's color #B695C0",
   "pixel x:1, y:4 changed to alice's color #9FBF95",


### PR DESCRIPTION
This PR builds on #24 to fix all instances when the random colour needs to be six hex digits by left-padding shorter values with zeros.