### PR TITLE
Refactor verification

### DIFF
--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -6,11 +6,7 @@ import harden from '@agoric/harden';
 import { makePrivateName } from '../util/PrivateName';
 import { allSettled } from '../util/allSettled';
 import { insist } from '../util/insist';
-import {
-  allComparable,
-  mustBeSameStructure,
-  sameStructure,
-} from '../util/sameStructure';
+import { allComparable, mustBeSameStructure, sameStructure } from '../util/sameStructure';
 import { makeUniAssayMaker } from './assays';
 import { makeMint } from './issuers';
 import { makeBasicMintController } from './mintController';
@@ -79,19 +75,11 @@ No invites left`;
     const installation = {};
     for (const fname of Object.getOwnPropertyNames(contractSrcs)) {
       if (typeof fname === 'string' && fname.startsWith('check')) {
-        installation[fname] = evaluateStringToFn(contractSrcs[fname]);
+        const fn = evaluateStringToFn(contractSrcs[fname]);
+        installation[fname] = (...args) => fn(installation, ...args);
       }
     }
     return installation;
-  }
-
-  function makeCheckInstallation(installation) {
-    return alleged => {
-      if (sameStructure(alleged, installation)) {
-        return installation;
-      }
-      return false;
-    };
   }
 
   /** The contract host is designed to have a long-lived credible identity. */
@@ -156,7 +144,6 @@ No invites left`;
       }
 
       installation.spawn = spawn;
-      installation.checkInstallation = makeCheckInstallation(installation);
       harden(installation);
       installationSources.init(installation, contractSrcs);
       return installation;

--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -6,7 +6,11 @@ import harden from '@agoric/harden';
 import { makePrivateName } from '../util/PrivateName';
 import { allSettled } from '../util/allSettled';
 import { insist } from '../util/insist';
-import { allComparable, mustBeSameStructure, sameStructure } from '../util/sameStructure';
+import {
+  allComparable,
+  mustBeSameStructure,
+  sameStructure,
+} from '../util/sameStructure';
 import { makeUniAssayMaker } from './assays';
 import { makeMint } from './issuers';
 import { makeBasicMintController } from './mintController';

--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -6,7 +6,7 @@ import harden from '@agoric/harden';
 import { makePrivateName } from '../util/PrivateName';
 import { allSettled } from '../util/allSettled';
 import { insist } from '../util/insist';
-import { mustBeSameStructure, allComparable } from '../util/sameStructure';
+import { allComparable, mustBeSameStructure } from '../util/sameStructure';
 import { makeUniAssayMaker } from './assays';
 import { makeMint } from './issuers';
 import { makeBasicMintController } from './mintController';
@@ -51,6 +51,12 @@ No invites left`;
   const contractHost = harden({
     getInviteIssuer() {
       return inviteIssuer;
+    },
+    getInviteIssuerLabel() {
+      return harden({
+        issuer: inviteIssuer,
+        description: 'contract host',
+      });
     },
 
     // The `contractSrc` is code for a contract function parameterized

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -2,54 +2,95 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import harden from '@agoric/harden';
+import { sameStructure } from '../util/sameStructure';
 
-function coveredCall(terms, inviteMaker) {
-  const [
-    escrowExchangeInstallationP,
-    moneyNeeded,
-    stockNeeded,
-    timerP,
-    deadline,
-  ] = terms;
+const coveredCallThunk = () =>
+  harden({
+    start(terms, inviteMaker) {
+      const [
+        escrowExchangeInstallationP,
+        moneyNeeded,
+        stockNeeded,
+        timerP,
+        deadline,
+      ] = terms;
 
-  const pairP = E(escrowExchangeInstallationP).spawn(
-    harden({ left: moneyNeeded, right: stockNeeded }),
-  );
+      const pairP = E(escrowExchangeInstallationP).spawn(
+        harden({ left: moneyNeeded, right: stockNeeded }),
+      );
 
-  const aliceEscrowSeatP = E.resolve(pairP).then(pair =>
-    inviteMaker.redeem(pair.left),
-  );
-  const bobEscrowSeatP = E.resolve(pairP).then(pair =>
-    inviteMaker.redeem(pair.right),
-  );
+      const aliceEscrowSeatP = E.resolve(pairP).then(pair =>
+        inviteMaker.redeem(pair.left),
+      );
+      const bobEscrowSeatP = E.resolve(pairP).then(pair =>
+        inviteMaker.redeem(pair.right),
+      );
 
-  // Seats
+      // Seats
 
-  E(timerP)
-    .delayUntil(deadline)
-    .then(_ => E(bobEscrowSeatP).cancel('expired'));
+      E(timerP)
+        .delayUntil(deadline)
+        .then(_ => E(bobEscrowSeatP).cancel('expired'));
 
-  const bobSeat = harden({
-    offer(stockPayment) {
-      const sIssuer = stockNeeded.label.issuer;
-      return E(sIssuer)
-        .getExclusive(stockNeeded, stockPayment, 'prePay')
-        .then(prePayment => {
-          E(bobEscrowSeatP).offer(prePayment);
-          return inviteMaker.make('holder', aliceEscrowSeatP);
-        });
+      const bobSeat = harden({
+        offer(stockPayment) {
+          const sIssuer = stockNeeded.label.issuer;
+          return E(sIssuer)
+            .getExclusive(stockNeeded, stockPayment, 'prePay')
+            .then(prePayment => {
+              E(bobEscrowSeatP).offer(prePayment);
+              return inviteMaker.make('holder', aliceEscrowSeatP);
+            });
+        },
+        getWinnings() {
+          return E(bobEscrowSeatP).getWinnings();
+        },
+        getRefund() {
+          return E(bobEscrowSeatP).getRefund();
+        },
+      });
+
+      return inviteMaker.make('writer', bobSeat);
     },
-    getWinnings() {
-      return E(bobEscrowSeatP).getWinnings();
-    },
-    getRefund() {
-      return E(bobEscrowSeatP).getRefund();
+    checkAmount(amount, terms) {
+      const [m, s, t, d] = terms;
+      const leftTerms = amount.quantity.terms[1];
+      if (m.quantity !== leftTerms.quantity) {
+        throw new Error(
+          `Wrong money quantity: ${m.quantity}, expected ${leftTerms.quantity}`,
+        );
+      }
+      if (!sameStructure(leftTerms, m)) {
+        throw new Error(`left terms incorrect: ${leftTerms}, expected ${m}`);
+      }
+      if (leftTerms.label.issuer !== m.label.issuer) {
+        const iss = leftTerms.label.issuer;
+        throw new Error(
+          `Wrong money issuer: ${m.label.description}, expected ${iss}`,
+        );
+      }
+      const rightTerms = amount.quantity.terms[2];
+      if (!sameStructure(rightTerms, s)) {
+        throw new Error(`right terms incorrect: ${rightTerms}, expected ${s}`);
+      }
+      if (rightTerms.quantity !== s.quantity) {
+        throw new Error(`Wrong right amount: ${s}, expected ${leftTerms}`);
+      }
+      if (amount.quantity.terms[4] !== d) {
+        throw new Error(
+          `Wrong deadline: ${amount.quantity.terms[4]}, expected ${d}`,
+        );
+      }
+      if (amount.quantity.terms[3] !== t) {
+        throw new Error(
+          `Wrong timer: ${amount.quantity.terms[3]}, expected ${t}`,
+        );
+      }
+      return true;
     },
   });
 
-  return inviteMaker.make('writer', bobSeat);
-}
-
-const coveredCallSrc = `(${coveredCall})`;
+const coveredCallSrc = `((${coveredCallThunk})())`;
+const coveredCall = coveredCallThunk();
 
 export { coveredCall, coveredCallSrc };

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import harden from '@agoric/harden';
-import { sameStructure } from '../util/sameStructure';
+import { mustBeSameStructure, sameStructure } from '../util/sameStructure';
 
 /**
  * The coveredCall is an asymmetric contract. One party will put some goods in
@@ -61,9 +61,15 @@ const coveredCall = {
 
     return inviteMaker.make('writer', bobSeat);
   },
-  checkAmount: (allegedInviteAmount, expectedTerms) => {
+  checkAmount: (installation, allegedInviteAmount, expectedTerms) => {
+    mustBeSameStructure(
+      allegedInviteAmount.quantity.installation,
+      installation,
+      'coveredCall checkAmount installation',
+    );
     const [termsMoney, termsStock, termsTimer, termsDeadline] = expectedTerms;
-    const allegedInviteMoney = allegedInviteAmount.quantity.terms.money;
+    const allegedInviteTerms = allegedInviteAmount.quantity.terms;
+    const allegedInviteMoney = allegedInviteTerms.money;
     if (allegedInviteMoney.quantity !== termsMoney.quantity) {
       throw new Error(
         `Wrong money quantity: ${allegedInviteMoney.quantity}, expected ${
@@ -76,39 +82,22 @@ const coveredCall = {
         `money terms incorrect: ${allegedInviteMoney}, expected ${termsMoney}`,
       );
     }
-    const allegedIssuer = allegedInviteMoney.label.issuer;
-    if (allegedIssuer !== termsMoney.label.issuer) {
-      throw new Error(
-        `Wrong money issuer: ${allegedIssuer}, expected ${
-          termsMoney.label.issuer
-        }`,
-      );
-    }
-    const allegedInviteStock = allegedInviteAmount.quantity.terms.stock;
+    const allegedInviteStock = allegedInviteTerms.stock;
     if (!sameStructure(allegedInviteStock, termsStock)) {
       throw new Error(
         `right terms incorrect: ${allegedInviteStock}, expected ${termsStock}`,
       );
     }
-    if (allegedInviteStock.quantity !== termsStock.quantity) {
-      throw new Error(
-        `Wrong stock quantity: ${allegedInviteStock.quantity}, expected ${
-          termsStock.quantity
-        }`,
-      );
-    }
-    if (allegedInviteAmount.quantity.terms.deadline !== termsDeadline) {
+    if (allegedInviteTerms.deadline !== termsDeadline) {
       throw new Error(
         `Wrong deadline: ${
-          allegedInviteAmount.quantity.terms.deadline
+          allegedInviteTerms.deadline
         }, expected ${termsDeadline}`,
       );
     }
-    if (termsTimer !== allegedInviteAmount.quantity.terms.timer) {
+    if (termsTimer !== allegedInviteTerms.timer) {
       throw new Error(
-        `Wrong timer: ${
-          allegedInviteAmount.quantity.terms.timer
-        }, expected ${termsTimer}`,
+        `Wrong timer: ${allegedInviteTerms.timer}, expected ${termsTimer}`,
       );
     }
     return true;

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -52,37 +52,49 @@ const coveredCall = {
     return inviteMaker.make('writer', bobSeat);
   },
   checkAmount: (amount, terms) => {
-    const [m, s, t, d] = terms;
-    const leftTerms = amount.quantity.terms[1];
-    if (m.quantity !== leftTerms.quantity) {
+    const [termsLeft, termsRight, termsTimer, termsDeadline] = terms;
+    const leftAmountTerms = amount.quantity.terms[1];
+    if (termsLeft.quantity !== leftAmountTerms.quantity) {
       throw new Error(
-        `Wrong money quantity: ${m.quantity}, expected ${leftTerms.quantity}`,
+        `Wrong money quantity: ${termsLeft.quantity}, expected ${
+          leftAmountTerms.quantity
+          }`,
       );
     }
-    if (!sameStructure(leftTerms, m)) {
-      throw new Error(`left terms incorrect: ${leftTerms}, expected ${m}`);
-    }
-    if (leftTerms.label.issuer !== m.label.issuer) {
-      const iss = leftTerms.label.issuer;
+    if (!sameStructure(termsLeft, leftAmountTerms)) {
       throw new Error(
-        `Wrong money issuer: ${m.label.description}, expected ${iss}`,
+        `left terms incorrect: ${termsLeft}, expected ${leftAmountTerms}`,
       );
     }
-    const rightTerms = amount.quantity.terms[2];
-    if (!sameStructure(rightTerms, s)) {
-      throw new Error(`right terms incorrect: ${rightTerms}, expected ${s}`);
-    }
-    if (rightTerms.quantity !== s.quantity) {
-      throw new Error(`Wrong right amount: ${s}, expected ${leftTerms}`);
-    }
-    if (amount.quantity.terms[4] !== d) {
+    const iss = leftAmountTerms.label.issuer;
+    if (termsLeft.label.issuer !== iss) {
       throw new Error(
-        `Wrong deadline: ${amount.quantity.terms[4]}, expected ${d}`,
+        `Wrong money issuer: ${termsLeft.label.issuer}, expected ${iss}`,
       );
     }
-    if (amount.quantity.terms[3] !== t) {
+    const rightAmountTerms = amount.quantity.terms[2];
+    if (!sameStructure(termsRight, rightAmountTerms)) {
       throw new Error(
-        `Wrong timer: ${amount.quantity.terms[3]}, expected ${t}`,
+        `right terms incorrect: ${termsRight}, expected ${rightAmountTerms}`,
+      );
+    }
+    if (termsRight.quantity !== rightAmountTerms.quantity) {
+      throw new Error(
+        `Wrong right quantity: ${termsRight.quantity}, expected ${
+          rightAmountTerms.quantity
+          }`,
+      );
+    }
+    if (termsDeadline !== amount.quantity.terms[4]) {
+      throw new Error(
+        `Wrong deadline: ${termsDeadline}, expected ${
+          amount.quantity.terms[4]
+          }`,
+      );
+    }
+    if (termsTimer !== amount.quantity.terms[3]) {
+      throw new Error(
+        `Wrong timer: ${termsTimer}, expected ${amount.quantity.terms[3]}`,
       );
     }
     return true;

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -72,9 +72,7 @@ const coveredCall = {
     const allegedInviteMoney = allegedInviteTerms.money;
     if (allegedInviteMoney.quantity !== termsMoney.quantity) {
       throw new Error(
-        `Wrong money quantity: ${allegedInviteMoney.quantity}, expected ${
-          termsMoney.quantity
-        }`,
+        `Wrong money quantity: ${allegedInviteMoney.quantity}, expected ${termsMoney.quantity}`,
       );
     }
     if (!sameStructure(allegedInviteMoney, termsMoney)) {
@@ -90,9 +88,7 @@ const coveredCall = {
     }
     if (allegedInviteTerms.deadline !== termsDeadline) {
       throw new Error(
-        `Wrong deadline: ${
-          allegedInviteTerms.deadline
-        }, expected ${termsDeadline}`,
+        `Wrong deadline: ${allegedInviteTerms.deadline}, expected ${termsDeadline}`,
       );
     }
     if (termsTimer !== allegedInviteTerms.timer) {

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -58,7 +58,7 @@ const coveredCall = {
       throw new Error(
         `Wrong money quantity: ${termsLeft.quantity}, expected ${
           leftAmountTerms.quantity
-          }`,
+        }`,
       );
     }
     if (!sameStructure(termsLeft, leftAmountTerms)) {
@@ -82,14 +82,14 @@ const coveredCall = {
       throw new Error(
         `Wrong right quantity: ${termsRight.quantity}, expected ${
           rightAmountTerms.quantity
-          }`,
+        }`,
       );
     }
     if (termsDeadline !== amount.quantity.terms[4]) {
       throw new Error(
         `Wrong deadline: ${termsDeadline}, expected ${
           amount.quantity.terms[4]
-          }`,
+        }`,
       );
     }
     if (termsTimer !== amount.quantity.terms[3]) {

--- a/core/coveredCall.js
+++ b/core/coveredCall.js
@@ -4,93 +4,94 @@
 import harden from '@agoric/harden';
 import { sameStructure } from '../util/sameStructure';
 
-const coveredCallThunk = () =>
-  harden({
-    start(terms, inviteMaker) {
-      const [
-        escrowExchangeInstallationP,
-        moneyNeeded,
-        stockNeeded,
-        timerP,
-        deadline,
-      ] = terms;
+const coveredCall = {
+  start: (terms, inviteMaker) => {
+    const [
+      escrowExchangeInstallationP,
+      moneyNeeded,
+      stockNeeded,
+      timerP,
+      deadline,
+    ] = terms;
 
-      const pairP = E(escrowExchangeInstallationP).spawn(
-        harden({ left: moneyNeeded, right: stockNeeded }),
+    const pairP = E(escrowExchangeInstallationP).spawn(
+      harden({ left: moneyNeeded, right: stockNeeded }),
+    );
+
+    const aliceEscrowSeatP = E.resolve(pairP).then(pair =>
+      inviteMaker.redeem(pair.left),
+    );
+    const bobEscrowSeatP = E.resolve(pairP).then(pair =>
+      inviteMaker.redeem(pair.right),
+    );
+
+    // Seats
+
+    E(timerP)
+      .delayUntil(deadline)
+      .then(_ => E(bobEscrowSeatP).cancel('expired'));
+
+    const bobSeat = harden({
+      offer(stockPayment) {
+        const sIssuer = stockNeeded.label.issuer;
+        return E(sIssuer)
+          .getExclusive(stockNeeded, stockPayment, 'prePay')
+          .then(prePayment => {
+            E(bobEscrowSeatP).offer(prePayment);
+            return inviteMaker.make('holder', aliceEscrowSeatP);
+          });
+      },
+      getWinnings() {
+        return E(bobEscrowSeatP).getWinnings();
+      },
+      getRefund() {
+        return E(bobEscrowSeatP).getRefund();
+      },
+    });
+
+    return inviteMaker.make('writer', bobSeat);
+  },
+  checkAmount: (amount, terms) => {
+    const [m, s, t, d] = terms;
+    const leftTerms = amount.quantity.terms[1];
+    if (m.quantity !== leftTerms.quantity) {
+      throw new Error(
+        `Wrong money quantity: ${m.quantity}, expected ${leftTerms.quantity}`,
       );
-
-      const aliceEscrowSeatP = E.resolve(pairP).then(pair =>
-        inviteMaker.redeem(pair.left),
+    }
+    if (!sameStructure(leftTerms, m)) {
+      throw new Error(`left terms incorrect: ${leftTerms}, expected ${m}`);
+    }
+    if (leftTerms.label.issuer !== m.label.issuer) {
+      const iss = leftTerms.label.issuer;
+      throw new Error(
+        `Wrong money issuer: ${m.label.description}, expected ${iss}`,
       );
-      const bobEscrowSeatP = E.resolve(pairP).then(pair =>
-        inviteMaker.redeem(pair.right),
+    }
+    const rightTerms = amount.quantity.terms[2];
+    if (!sameStructure(rightTerms, s)) {
+      throw new Error(`right terms incorrect: ${rightTerms}, expected ${s}`);
+    }
+    if (rightTerms.quantity !== s.quantity) {
+      throw new Error(`Wrong right amount: ${s}, expected ${leftTerms}`);
+    }
+    if (amount.quantity.terms[4] !== d) {
+      throw new Error(
+        `Wrong deadline: ${amount.quantity.terms[4]}, expected ${d}`,
       );
+    }
+    if (amount.quantity.terms[3] !== t) {
+      throw new Error(
+        `Wrong timer: ${amount.quantity.terms[3]}, expected ${t}`,
+      );
+    }
+    return true;
+  },
+};
 
-      // Seats
+const coveredCallSrc = {
+  start: `${coveredCall.start}`,
+  checkAmount: `${coveredCall.checkAmount}`,
+};
 
-      E(timerP)
-        .delayUntil(deadline)
-        .then(_ => E(bobEscrowSeatP).cancel('expired'));
-
-      const bobSeat = harden({
-        offer(stockPayment) {
-          const sIssuer = stockNeeded.label.issuer;
-          return E(sIssuer)
-            .getExclusive(stockNeeded, stockPayment, 'prePay')
-            .then(prePayment => {
-              E(bobEscrowSeatP).offer(prePayment);
-              return inviteMaker.make('holder', aliceEscrowSeatP);
-            });
-        },
-        getWinnings() {
-          return E(bobEscrowSeatP).getWinnings();
-        },
-        getRefund() {
-          return E(bobEscrowSeatP).getRefund();
-        },
-      });
-
-      return inviteMaker.make('writer', bobSeat);
-    },
-    checkAmount(amount, terms) {
-      const [m, s, t, d] = terms;
-      const leftTerms = amount.quantity.terms[1];
-      if (m.quantity !== leftTerms.quantity) {
-        throw new Error(
-          `Wrong money quantity: ${m.quantity}, expected ${leftTerms.quantity}`,
-        );
-      }
-      if (!sameStructure(leftTerms, m)) {
-        throw new Error(`left terms incorrect: ${leftTerms}, expected ${m}`);
-      }
-      if (leftTerms.label.issuer !== m.label.issuer) {
-        const iss = leftTerms.label.issuer;
-        throw new Error(
-          `Wrong money issuer: ${m.label.description}, expected ${iss}`,
-        );
-      }
-      const rightTerms = amount.quantity.terms[2];
-      if (!sameStructure(rightTerms, s)) {
-        throw new Error(`right terms incorrect: ${rightTerms}, expected ${s}`);
-      }
-      if (rightTerms.quantity !== s.quantity) {
-        throw new Error(`Wrong right amount: ${s}, expected ${leftTerms}`);
-      }
-      if (amount.quantity.terms[4] !== d) {
-        throw new Error(
-          `Wrong deadline: ${amount.quantity.terms[4]}, expected ${d}`,
-        );
-      }
-      if (amount.quantity.terms[3] !== t) {
-        throw new Error(
-          `Wrong timer: ${amount.quantity.terms[3]}, expected ${t}`,
-        );
-      }
-      return true;
-    },
-  });
-
-const coveredCallSrc = `((${coveredCallThunk})())`;
-const coveredCall = coveredCallThunk();
-
-export { coveredCall, coveredCallSrc };
+export { coveredCallSrc };

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import harden from '@agoric/harden';
-import { mustBeSameStructure, sameStructure } from '../util/sameStructure';
+import { mustBeSameStructure } from '../util/sameStructure';
 
 // For clarity, the code below internally speaks of a scenario is which Alice is
 // trading some of her money for some of Bob's stock. However, for generality,
@@ -92,26 +92,35 @@ const escrowExchange = {
     });
   },
 
-  checkAmount: (allegedInviteAmount, expectedTerms) => {
+  checkAmount: (installation, allegedInviteAmount, expectedTerms, seat) => {
+    mustBeSameStructure(allegedInviteAmount.quantity.seatDesc, seat);
     const allegedTerms = allegedInviteAmount.quantity.terms;
     mustBeSameStructure(allegedTerms, expectedTerms, 'Escrow checkAmount');
+    mustBeSameStructure(
+      allegedInviteAmount.quantity.installation,
+      installation,
+      'escrow checkAmount installation',
+    );
     return true;
   },
 
   // Check the left or right side, and return the other. Useful when this is a
   // trade of goods for an invite, for example.
-  checkPartialAmount: (allegedInvite, expectedTerms, seat) => {
+  checkPartialAmount: (installation, allegedInvite, expectedTerms, seat) => {
     const allegedSeat = allegedInvite.quantity.terms;
     mustBeSameStructure(
-      allegedSeat,
+      allegedSeat[seat],
       expectedTerms,
-      'Escrow checkPartialAmount',
+      'Escrow checkPartialAmount seat',
     );
-    mustBeSameStructure(allegedInvite.quantity.seatDesc, seat);
-    if (seat === 'left') {
-      return allegedInvite.quantity.terms.right;
-    }
-    return allegedInvite.quantity.terms.left;
+
+    mustBeSameStructure(
+      allegedInvite.quantity.installation,
+      installation,
+      'escrow checkPartialAmount installation',
+    );
+
+    return seat === 'left' ? allegedSeat.right : allegedSeat.left;
   },
 };
 

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import harden from '@agoric/harden';
+import { sameStructure } from '../util/sameStructure';
 
 // For clarity, the code below internally speaks of a scenario is
 // which Alice is trading some of her money for some of Bob's
@@ -10,87 +11,134 @@ import harden from '@agoric/harden';
 // players 0 and 1. Money are the rights transfered from player 0 to
 // 1, and Stock are the rights transfered from 1 to 0.
 
-function escrowExchange(terms, inviteMaker) {
-  const { left: moneyNeeded, right: stockNeeded } = terms;
+const escrowExchangeThunk = () =>
+  harden({
+    start(terms, inviteMaker) {
+      const { left: moneyNeeded, right: stockNeeded } = terms;
 
-  function makeTransfer(amount, srcPaymentP) {
-    const { issuer } = amount.label;
-    const escrowP = E(issuer).getExclusive(amount, srcPaymentP, 'escrow');
-    const winnings = makePromise();
-    const refund = makePromise();
-    return harden({
-      phase1() {
-        return escrowP;
-      },
-      phase2() {
-        winnings.res(escrowP);
-        refund.res(null);
-      },
-      abort(reason) {
-        winnings.reject(reason);
-        refund.res(escrowP);
-      },
-      getWinnings() {
-        return winnings.p;
-      },
-      getRefund() {
-        return refund.p;
-      },
-    });
-  }
+      function makeTransfer(amount, srcPaymentP) {
+        const { issuer } = amount.label;
+        const escrowP = E(issuer).getExclusive(amount, srcPaymentP, 'escrow');
+        const winnings = makePromise();
+        const refund = makePromise();
+        return harden({
+          phase1() {
+            return escrowP;
+          },
+          phase2() {
+            winnings.res(escrowP);
+            refund.res(null);
+          },
+          abort(reason) {
+            winnings.reject(reason);
+            refund.res(escrowP);
+          },
+          getWinnings() {
+            return winnings.p;
+          },
+          getRefund() {
+            return refund.p;
+          },
+        });
+      }
 
-  // Promise wiring
+      // Promise wiring
 
-  const moneyPayment = makePromise();
-  const moneyTransfer = makeTransfer(moneyNeeded, moneyPayment.p);
+      const moneyPayment = makePromise();
+      const moneyTransfer = makeTransfer(moneyNeeded, moneyPayment.p);
 
-  const stockPayment = makePromise();
-  const stockTransfer = makeTransfer(stockNeeded, stockPayment.p);
+      const stockPayment = makePromise();
+      const stockTransfer = makeTransfer(stockNeeded, stockPayment.p);
 
-  // TODO Use cancellation tokens instead.
-  const aliceCancel = makePromise();
-  const bobCancel = makePromise();
+      // TODO Use cancellation tokens instead.
+      const aliceCancel = makePromise();
+      const bobCancel = makePromise();
 
-  // Set it all in motion optimistically.
+      // Set it all in motion optimistically.
 
-  const decisionP = Promise.race([
-    Promise.all([moneyTransfer.phase1(), stockTransfer.phase1()]),
-    aliceCancel.p,
-    bobCancel.p,
-  ]);
-  decisionP.then(
-    _ => {
-      moneyTransfer.phase2();
-      stockTransfer.phase2();
+      const decisionP = Promise.race([
+        Promise.all([moneyTransfer.phase1(), stockTransfer.phase1()]),
+        aliceCancel.p,
+        bobCancel.p,
+      ]);
+      decisionP.then(
+        _ => {
+          moneyTransfer.phase2();
+          stockTransfer.phase2();
+        },
+        reason => {
+          moneyTransfer.abort(reason);
+          stockTransfer.abort(reason);
+        },
+      );
+
+      // Seats
+
+      const aliceSeat = harden({
+        offer: moneyPayment.res,
+        cancel: aliceCancel.reject,
+        getWinnings: stockTransfer.getWinnings,
+        getRefund: moneyTransfer.getRefund,
+      });
+
+      const bobSeat = harden({
+        offer: stockPayment.res,
+        cancel: bobCancel.reject,
+        getWinnings: moneyTransfer.getWinnings,
+        getRefund: stockTransfer.getRefund,
+      });
+
+      return harden({
+        left: inviteMaker.make('left', aliceSeat),
+        right: inviteMaker.make('right', bobSeat),
+      });
     },
-    reason => {
-      moneyTransfer.abort(reason);
-      stockTransfer.abort(reason);
+    checkAmount(amount, payment) {
+      const termsFromAmount = amount.quantity.terms;
+      if (!sameStructure(termsFromAmount, payment)) {
+        throw new Error(
+          `Wrong amount: ${payment}, expected ${termsFromAmount}`,
+        );
+      }
+      if (termsFromAmount.left.quantity !== payment.left.quantity) {
+        throw new Error(
+          `Wrong left quantity: ${payment.left.quantity}, expected ${
+            termsFromAmount.left.quantity
+          }`,
+        );
+      }
+      if (termsFromAmount.right.quantity !== payment.right.quantity) {
+        throw new Error(
+          `Wrong right quantity: ${payment.right.quantity}, expected ${
+            termsFromAmount.right.quantity
+          }`,
+        );
+      }
+      return true;
     },
-  );
-
-  // Seats
-
-  const aliceSeat = harden({
-    offer: moneyPayment.res,
-    cancel: aliceCancel.reject,
-    getWinnings: stockTransfer.getWinnings,
-    getRefund: moneyTransfer.getRefund,
+    // Check the left or right side, and return the other. Useful when it's a
+    // trade of goods for an invite.
+    checkPartialAmount(amount, payment) {
+      const seat = amount.quantity.seatDesc;
+      const terms = amount.quantity.terms[seat];
+      if (terms.quantity !== payment.quantity) {
+        throw new Error(
+          `Wrong ${seat} quantity: ${payment.quantity}, expected ${
+            terms.quantity
+          }`,
+        );
+      }
+      if (!sameStructure(terms, payment)) {
+        throw new Error(`Wrong ${seat} amount: ${payment}, expected ${terms}`);
+      }
+      if (seat === 'left') {
+        return amount.quantity.terms.right;
+      }
+      return amount.quantity.terms.left;
+    },
   });
 
-  const bobSeat = harden({
-    offer: stockPayment.res,
-    cancel: bobCancel.reject,
-    getWinnings: moneyTransfer.getWinnings,
-    getRefund: stockTransfer.getRefund,
-  });
-
-  return harden({
-    left: inviteMaker.make('left', aliceSeat),
-    right: inviteMaker.make('right', bobSeat),
-  });
-}
-
-const escrowExchangeSrc = `(${escrowExchange})`;
+const escrowExchangeSrc = `((${escrowExchangeThunk})())`;
+const escrowExchange = escrowExchangeThunk();
 
 export { escrowExchange, escrowExchangeSrc };

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -94,17 +94,17 @@ const escrowExchange = {
 
   checkAmount: (amount, payment) => {
     const termsFromAmount = amount.quantity.terms;
-    if (!sameStructure(termsFromAmount, payment)) {
+    if (!sameStructure(payment, termsFromAmount)) {
       throw new Error(`Wrong amount: ${payment}, expected ${termsFromAmount}`);
     }
-    if (termsFromAmount.left.quantity !== payment.left.quantity) {
+    if (payment.left.quantity !== termsFromAmount.left.quantity) {
       throw new Error(
         `Wrong left quantity: ${payment.left.quantity}, expected ${
           termsFromAmount.left.quantity
         }`,
       );
     }
-    if (termsFromAmount.right.quantity !== payment.right.quantity) {
+    if (payment.right.quantity !== termsFromAmount.right.quantity) {
       throw new Error(
         `Wrong right quantity: ${payment.right.quantity}, expected ${
           termsFromAmount.right.quantity
@@ -114,12 +114,12 @@ const escrowExchange = {
     return true;
   },
 
-  // Check the left or right side, and return the other. Useful when it's a
+  // Check the left or right side, and return the other. Useful when this is a
   // trade of goods for an invite, for example.
   checkPartialAmount: (amount, payment) => {
     const seat = amount.quantity.seatDesc;
     const terms = amount.quantity.terms[seat];
-    if (terms.quantity !== payment.quantity) {
+    if (payment.quantity !== terms.quantity) {
       throw new Error(
         `Wrong ${seat} quantity: ${payment.quantity}, expected ${
           terms.quantity
@@ -127,7 +127,7 @@ const escrowExchange = {
       );
     }
     if (!sameStructure(terms, payment)) {
-      throw new Error(`Wrong ${seat} amount: ${payment}, expected ${terms}`);
+      throw new Error(`Wrong ${seat} amount: ${terms}, expected ${payment}`);
     }
     if (seat === 'left') {
       return amount.quantity.terms.right;

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -101,14 +101,14 @@ const escrowExchange = {
       throw new Error(
         `Wrong left quantity: ${payment.left.quantity}, expected ${
           termsFromAmount.left.quantity
-          }`,
+        }`,
       );
     }
     if (termsFromAmount.right.quantity !== payment.right.quantity) {
       throw new Error(
         `Wrong right quantity: ${payment.right.quantity}, expected ${
           termsFromAmount.right.quantity
-          }`,
+        }`,
       );
     }
     return true;
@@ -123,7 +123,7 @@ const escrowExchange = {
       throw new Error(
         `Wrong ${seat} quantity: ${payment.quantity}, expected ${
           terms.quantity
-          }`,
+        }`,
       );
     }
     if (!sameStructure(terms, payment)) {

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -4,141 +4,142 @@
 import harden from '@agoric/harden';
 import { sameStructure } from '../util/sameStructure';
 
-// For clarity, the code below internally speaks of a scenario is
-// which Alice is trading some of her money for some of Bob's
-// stock. However, for generality, the API does not expose names like
-// "alice", "bob", "money", or "stock". Rather, Alice and Bob are
-// players 0 and 1. Money are the rights transfered from player 0 to
-// 1, and Stock are the rights transfered from 1 to 0.
+// For clarity, the code below internally speaks of a scenario is which Alice is
+// trading some of her money for some of Bob's stock. However, for generality,
+// the API does not expose names like "alice", "bob", "money", or "stock".
+// Rather, Alice and Bob are left and right respectively. Money are the rights
+// transferred from left to right, and Stock is the rights transferred from
+// right to left.
+const escrowExchange = {
+  start: (terms, inviteMaker) => {
+    const { left: moneyNeeded, right: stockNeeded } = terms;
 
-const escrowExchangeThunk = () =>
-  harden({
-    start(terms, inviteMaker) {
-      const { left: moneyNeeded, right: stockNeeded } = terms;
-
-      function makeTransfer(amount, srcPaymentP) {
-        const { issuer } = amount.label;
-        const escrowP = E(issuer).getExclusive(amount, srcPaymentP, 'escrow');
-        const winnings = makePromise();
-        const refund = makePromise();
-        return harden({
-          phase1() {
-            return escrowP;
-          },
-          phase2() {
-            winnings.res(escrowP);
-            refund.res(null);
-          },
-          abort(reason) {
-            winnings.reject(reason);
-            refund.res(escrowP);
-          },
-          getWinnings() {
-            return winnings.p;
-          },
-          getRefund() {
-            return refund.p;
-          },
-        });
-      }
-
-      // Promise wiring
-
-      const moneyPayment = makePromise();
-      const moneyTransfer = makeTransfer(moneyNeeded, moneyPayment.p);
-
-      const stockPayment = makePromise();
-      const stockTransfer = makeTransfer(stockNeeded, stockPayment.p);
-
-      // TODO Use cancellation tokens instead.
-      const aliceCancel = makePromise();
-      const bobCancel = makePromise();
-
-      // Set it all in motion optimistically.
-
-      const decisionP = Promise.race([
-        Promise.all([moneyTransfer.phase1(), stockTransfer.phase1()]),
-        aliceCancel.p,
-        bobCancel.p,
-      ]);
-      decisionP.then(
-        _ => {
-          moneyTransfer.phase2();
-          stockTransfer.phase2();
-        },
-        reason => {
-          moneyTransfer.abort(reason);
-          stockTransfer.abort(reason);
-        },
-      );
-
-      // Seats
-
-      const aliceSeat = harden({
-        offer: moneyPayment.res,
-        cancel: aliceCancel.reject,
-        getWinnings: stockTransfer.getWinnings,
-        getRefund: moneyTransfer.getRefund,
-      });
-
-      const bobSeat = harden({
-        offer: stockPayment.res,
-        cancel: bobCancel.reject,
-        getWinnings: moneyTransfer.getWinnings,
-        getRefund: stockTransfer.getRefund,
-      });
-
+    function makeTransfer(amount, srcPaymentP) {
+      const { issuer } = amount.label;
+      const escrowP = E(issuer).getExclusive(amount, srcPaymentP, 'escrow');
+      const winnings = makePromise();
+      const refund = makePromise();
       return harden({
-        left: inviteMaker.make('left', aliceSeat),
-        right: inviteMaker.make('right', bobSeat),
+        phase1() {
+          return escrowP;
+        },
+        phase2() {
+          winnings.res(escrowP);
+          refund.res(null);
+        },
+        abort(reason) {
+          winnings.reject(reason);
+          refund.res(escrowP);
+        },
+        getWinnings() {
+          return winnings.p;
+        },
+        getRefund() {
+          return refund.p;
+        },
       });
-    },
-    checkAmount(amount, payment) {
-      const termsFromAmount = amount.quantity.terms;
-      if (!sameStructure(termsFromAmount, payment)) {
-        throw new Error(
-          `Wrong amount: ${payment}, expected ${termsFromAmount}`,
-        );
-      }
-      if (termsFromAmount.left.quantity !== payment.left.quantity) {
-        throw new Error(
-          `Wrong left quantity: ${payment.left.quantity}, expected ${
-            termsFromAmount.left.quantity
-          }`,
-        );
-      }
-      if (termsFromAmount.right.quantity !== payment.right.quantity) {
-        throw new Error(
-          `Wrong right quantity: ${payment.right.quantity}, expected ${
-            termsFromAmount.right.quantity
-          }`,
-        );
-      }
-      return true;
-    },
-    // Check the left or right side, and return the other. Useful when it's a
-    // trade of goods for an invite.
-    checkPartialAmount(amount, payment) {
-      const seat = amount.quantity.seatDesc;
-      const terms = amount.quantity.terms[seat];
-      if (terms.quantity !== payment.quantity) {
-        throw new Error(
-          `Wrong ${seat} quantity: ${payment.quantity}, expected ${
-            terms.quantity
-          }`,
-        );
-      }
-      if (!sameStructure(terms, payment)) {
-        throw new Error(`Wrong ${seat} amount: ${payment}, expected ${terms}`);
-      }
-      if (seat === 'left') {
-        return amount.quantity.terms.right;
-      }
-      return amount.quantity.terms.left;
-    },
-  });
+    }
 
-const escrowExchangeSrc = `((${escrowExchangeThunk})())`;
-const escrowExchange = escrowExchangeThunk();
+    // Promise wiring
 
-export { escrowExchange, escrowExchangeSrc };
+    const moneyPayment = makePromise();
+    const moneyTransfer = makeTransfer(moneyNeeded, moneyPayment.p);
+
+    const stockPayment = makePromise();
+    const stockTransfer = makeTransfer(stockNeeded, stockPayment.p);
+
+    // TODO Use cancellation tokens instead.
+    const aliceCancel = makePromise();
+    const bobCancel = makePromise();
+
+    // Set it all in motion optimistically.
+
+    const decisionP = Promise.race([
+      Promise.all([moneyTransfer.phase1(), stockTransfer.phase1()]),
+      aliceCancel.p,
+      bobCancel.p,
+    ]);
+    decisionP.then(
+      _ => {
+        moneyTransfer.phase2();
+        stockTransfer.phase2();
+      },
+      reason => {
+        moneyTransfer.abort(reason);
+        stockTransfer.abort(reason);
+      },
+    );
+
+    // Seats
+
+    const aliceSeat = harden({
+      offer: moneyPayment.res,
+      cancel: aliceCancel.reject,
+      getWinnings: stockTransfer.getWinnings,
+      getRefund: moneyTransfer.getRefund,
+    });
+
+    const bobSeat = harden({
+      offer: stockPayment.res,
+      cancel: bobCancel.reject,
+      getWinnings: moneyTransfer.getWinnings,
+      getRefund: stockTransfer.getRefund,
+    });
+
+    return harden({
+      left: inviteMaker.make('left', aliceSeat),
+      right: inviteMaker.make('right', bobSeat),
+    });
+  },
+
+  checkAmount: (amount, payment) => {
+    const termsFromAmount = amount.quantity.terms;
+    if (!sameStructure(termsFromAmount, payment)) {
+      throw new Error(`Wrong amount: ${payment}, expected ${termsFromAmount}`);
+    }
+    if (termsFromAmount.left.quantity !== payment.left.quantity) {
+      throw new Error(
+        `Wrong left quantity: ${payment.left.quantity}, expected ${
+          termsFromAmount.left.quantity
+          }`,
+      );
+    }
+    if (termsFromAmount.right.quantity !== payment.right.quantity) {
+      throw new Error(
+        `Wrong right quantity: ${payment.right.quantity}, expected ${
+          termsFromAmount.right.quantity
+          }`,
+      );
+    }
+    return true;
+  },
+
+  // Check the left or right side, and return the other. Useful when it's a
+  // trade of goods for an invite, for example.
+  checkPartialAmount: (amount, payment) => {
+    const seat = amount.quantity.seatDesc;
+    const terms = amount.quantity.terms[seat];
+    if (terms.quantity !== payment.quantity) {
+      throw new Error(
+        `Wrong ${seat} quantity: ${payment.quantity}, expected ${
+          terms.quantity
+          }`,
+      );
+    }
+    if (!sameStructure(terms, payment)) {
+      throw new Error(`Wrong ${seat} amount: ${payment}, expected ${terms}`);
+    }
+    if (seat === 'left') {
+      return amount.quantity.terms.right;
+    }
+    return amount.quantity.terms.left;
+  },
+};
+
+const escrowExchangeSrc = {
+  start: `${escrowExchange.start}`,
+  checkAmount: `${escrowExchange.checkAmount}`,
+  checkPartialAmount: `${escrowExchange.checkPartialAmount}`,
+};
+
+export { escrowExchangeSrc };

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -32,9 +32,6 @@ Description must be truthy: ${description}`;
       getIssuer() {
         return issuer;
       },
-      getIssuerLabel() {
-        return issuer.getLabel();
-      },
       getBalance() {
         return mintController.getAmount(payment);
       },
@@ -50,6 +47,10 @@ Description must be truthy: ${description}`;
 
     getAssay() {
       return assay;
+    },
+
+    makeAmount(quantity) {
+      return assay.make(quantity);
     },
 
     makeEmptyPurse(name = 'a purse') {
@@ -118,9 +119,6 @@ Description must be truthy: ${description}`;
     getIssuer() {
       return issuer;
     },
-    getIssuerLabel() {
-      return issuer.getLabel();
-    },
     destroyAll() {
       mintController.destroyAll();
     },
@@ -141,9 +139,6 @@ Description must be truthy: ${description}`;
       const purse = harden({
         getIssuer() {
           return issuer;
-        },
-        getIssuerLabel() {
-          return issuer.getLabel();
         },
         getBalance() {
           return mintController.getAmount(purse);

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -32,6 +32,9 @@ Description must be truthy: ${description}`;
       getIssuer() {
         return issuer;
       },
+      getIssuerLabel() {
+        return issuer.getLabel();
+      },
       getBalance() {
         return mintController.getAmount(payment);
       },
@@ -115,6 +118,9 @@ Description must be truthy: ${description}`;
     getIssuer() {
       return issuer;
     },
+    getIssuerLabel() {
+      return issuer.getLabel();
+    },
     destroyAll() {
       mintController.destroyAll();
     },
@@ -135,6 +141,9 @@ Description must be truthy: ${description}`;
       const purse = harden({
         getIssuer() {
           return issuer;
+        },
+        getIssuerLabel() {
+          return issuer.getLabel();
         },
         getBalance() {
           return mintController.getAmount(purse);

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -85,20 +85,19 @@ function build(E, log) {
   function trivialContractTest(host) {
     log('starting trivialContractTest');
 
-    const trivContractThunk = () =>
-      harden({
-        start(terms, inviteMaker) {
-          return inviteMaker.make('foo', 8);
-        },
-      });
-    const contractSrc = `((${trivContractThunk})())`;
+    const trivContract = {
+      start: (terms, inviteMaker) => {
+        return inviteMaker.make('foo', 8);
+      },
+    };
+    const contractSrc = { start: `${trivContract.start} ` };
 
     const installationP = E(host).install(contractSrc);
 
     return E(host)
       .getInstallationSourceCode(installationP)
       .then(src => {
-        log('Does contract source match? ', src === contractSrc);
+        log('Does source ', src, ' match? ', src.start === contractSrc.start);
 
         const fooInviteP = E(installationP).spawn('foo terms');
 

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -2,8 +2,8 @@
 
 import harden from '@agoric/harden';
 
-import { escrowExchangeSrc } from '../../core/escrow';
-import { coveredCallSrc } from '../../core/coveredCall';
+import { escrowExchangeSrcs } from '../../core/escrow';
+import { coveredCallSrcs } from '../../core/coveredCall';
 
 function build(E, log) {
   // TODO BUG: All callers should wait until settled before doing
@@ -90,14 +90,14 @@ function build(E, log) {
         return inviteMaker.make('foo', 8);
       },
     };
-    const contractSrc = { start: `${trivContract.start} ` };
+    const contractSrcs = { start: `${trivContract.start} ` };
 
-    const installationP = E(host).install(contractSrc);
+    const installationP = E(host).install(contractSrcs);
 
     return E(host)
       .getInstallationSourceCode(installationP)
       .then(src => {
-        log('Does source ', src, ' match? ', src.start === contractSrc.start);
+        log('Does source ', src, ' match? ', src.start === contractSrcs.start);
 
         const fooInviteP = E(installationP).spawn('foo terms');
 
@@ -118,8 +118,8 @@ function build(E, log) {
   }
 
   function betterContractTestAliceFirst(host, mint, aliceMaker, bobMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('moola');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000);
@@ -157,8 +157,8 @@ function build(E, log) {
   }
 
   function betterContractTestBobFirst(host, mint, aliceMaker, bobMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('clams');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000, 'aliceMainMoney');
@@ -202,8 +202,8 @@ function build(E, log) {
   }
 
   function coveredCallTest(host, mint, aliceMaker, bobMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('smackers');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000, 'aliceMainMoney');
@@ -247,8 +247,8 @@ function build(E, log) {
   }
 
   function coveredCallSaleTest(host, mint, aliceMaker, bobMaker, fredMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const doughMintP = E(mint).makeMint('dough');
     const aliceDoughPurseP = E(doughMintP).mint(1000, 'aliceDough');

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -97,7 +97,7 @@ function build(E, log) {
     return E(host)
       .getInstallationSourceCode(installationP)
       .then(src => {
-        log('Does source ', src, ' match? ', src.start === contractSrcs.start);
+        log('Does source match? ', src.start === contractSrcs.start);
 
         const fooInviteP = E(installationP).spawn('foo terms');
 

--- a/demo/contractHost/bootstrap.js
+++ b/demo/contractHost/bootstrap.js
@@ -85,10 +85,13 @@ function build(E, log) {
   function trivialContractTest(host) {
     log('starting trivialContractTest');
 
-    function trivContract(terms, inviteMaker) {
-      return inviteMaker.make('foo', 8);
-    }
-    const contractSrc = `${trivContract}`;
+    const trivContractThunk = () =>
+      harden({
+        start(terms, inviteMaker) {
+          return inviteMaker.make('foo', 8);
+        },
+      });
+    const contractSrc = `((${trivContractThunk})())`;
 
     const installationP = E(host).install(contractSrc);
 

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -41,7 +41,7 @@ function makeAliceMaker(E, host, log) {
           showPaymentBalance('alice invite', allegedInvitePaymentP);
           const clams10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
           const fudco7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
-          const verifiedInviteP = E(allegedInvitePaymentP)
+          const verifiedInvitePaymentP = E(allegedInvitePaymentP)
             .getBalance()
             .then(allegedInviteAmount => {
               return E.resolve(Promise.all([clams10P, fudco7P])).then(terms => {
@@ -59,9 +59,9 @@ function makeAliceMaker(E, host, log) {
             });
 
           return E.resolve(
-            showPaymentBalance('verified invite', verifiedInviteP),
+            showPaymentBalance('verified invite', verifiedInvitePaymentP),
           ).then(_ => {
-            const seatP = E(host).redeem(verifiedInviteP);
+            const seatP = E(host).redeem(verifiedInvitePaymentP);
             const moneyPaymentP = E(myMoneyPurseP).withdraw(10);
             E(seatP).offer(moneyPaymentP);
             return collect(seatP, myStockPurseP, myMoneyPurseP, 'alice escrow');
@@ -123,13 +123,17 @@ function makeAliceMaker(E, host, log) {
           const inviteNeededP = E(allegedInvitePaymentP).getBalance();
 
           const terms = harden({ left: finNeededP, right: inviteNeededP });
-          const invitesP = E(escrowExchangeInstallationP).spawn(terms);
-          const fredInviteP = invitesP.then(invites => invites.left);
-          const aliceForFredInviteP = invitesP.then(invites => invites.right);
+          const invitePaymentsP = E(escrowExchangeInstallationP).spawn(terms);
+          const fredInvitePaymentP = invitePaymentsP.then(
+            invitePayments => invitePayments.left,
+          );
+          const aliceForFredInvitePaymentP = invitePaymentsP.then(
+            invitePayments => invitePayments.right,
+          );
           const doneP = Promise.all([
-            E(optFredP).acceptOptionOffer(fredInviteP),
+            E(optFredP).acceptOptionOffer(fredInvitePaymentP),
             E(alice).completeOptionsSale(
-              aliceForFredInviteP,
+              aliceForFredInvitePaymentP,
               allegedInvitePaymentP,
             ),
           ]);
@@ -140,9 +144,9 @@ function makeAliceMaker(E, host, log) {
           return doneP;
         },
 
-        completeOptionsSale(aliceForFredInviteP, allegedInvitePaymentP) {
+        completeOptionsSale(aliceForFredInvitePaymentP, allegedInvitePaymentP) {
           log('++ alice.completeOptionsSale starting');
-          const aliceForFredSeatP = E(host).redeem(aliceForFredInviteP);
+          const aliceForFredSeatP = E(host).redeem(aliceForFredInvitePaymentP);
 
           E(aliceForFredSeatP).offer(allegedInvitePaymentP);
           const myInvitePurseP = E(inviteIssuerP).makeEmptyPurse();

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -3,6 +3,7 @@
 
 import harden from '@agoric/harden';
 import { makeCollect } from '../../core/contractHost';
+import { allComparable } from '../../util/sameStructure';
 
 function makeAliceMaker(E, host, log) {
   const collect = makeCollect(E, log);
@@ -46,13 +47,17 @@ function makeAliceMaker(E, host, log) {
               return E.resolve(Promise.all([clams10P, fudco7P])).then(terms => {
                 const [left, right] = terms;
                 return E(escrowExchangeInstallationP)
-                  .checkAmount(allegedInviteAmount, { left, right })
-                  .then(() => {
-                    return E(inviteIssuerP).getExclusive(
-                      allegedInviteAmount,
-                      allegedInvitePaymentP,
-                      'verified invite',
-                    );
+                  .checkInstallation(allegedInviteAmount.quantity.installation)
+                  .then(validEscrowInstallationP => {
+                    return E(validEscrowInstallationP)
+                      .checkAmount(allegedInviteAmount, { left, right })
+                      .then(() => {
+                        return E(inviteIssuerP).getExclusive(
+                          allegedInviteAmount,
+                          allegedInvitePaymentP,
+                          'verified invite',
+                        );
+                      });
                   });
               });
             });
@@ -86,13 +91,13 @@ function makeAliceMaker(E, host, log) {
                 10,
               );
               const yoyodyne7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
-              const coveredCallTermsP = [
+              const coveredCallTermsP = harden([
                 smackers10P,
                 yoyodyne7P,
                 timerP,
                 'singularity',
-              ];
-              return E.resolve(Promise.all(coveredCallTermsP)).then(terms => {
+              ]);
+              return E.resolve(allComparable(coveredCallTermsP)).then(terms => {
                 return E(coveredCallInstallationP)
                   .checkAmount(allegedInviteAmount, terms)
                   .then(_ => {

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -82,7 +82,9 @@ function makeAliceMaker(E, host, log) {
 
           const verifiedInvitePaymentP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
-              const smackers10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
+              const smackers10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(
+                10,
+              );
               const yoyodyne7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
               const coveredCallTermsP = [
                 smackers10P,

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -47,17 +47,13 @@ function makeAliceMaker(E, host, log) {
               return E.resolve(Promise.all([clams10P, fudco7P])).then(terms => {
                 const [left, right] = terms;
                 return E(escrowExchangeInstallationP)
-                  .checkInstallation(allegedInviteAmount.quantity.installation)
-                  .then(validEscrowInstallationP => {
-                    return E(validEscrowInstallationP)
-                      .checkAmount(allegedInviteAmount, { left, right })
-                      .then(() => {
-                        return E(inviteIssuerP).getExclusive(
-                          allegedInviteAmount,
-                          allegedInvitePaymentP,
-                          'verified invite',
-                        );
-                      });
+                  .checkAmount(allegedInviteAmount, { left, right }, 'left')
+                  .then(() => {
+                    return E(inviteIssuerP).getExclusive(
+                      allegedInviteAmount,
+                      allegedInvitePaymentP,
+                      'verified invite',
+                    );
                   });
               });
             });

--- a/demo/contractHost/vat-alice.js
+++ b/demo/contractHost/vat-alice.js
@@ -38,12 +38,12 @@ function makeAliceMaker(E, host, log) {
         acceptInvite(allegedInvitePaymentP) {
           log('++ alice.acceptInvite starting');
           showPaymentBalance('alice invite', allegedInvitePaymentP);
-          const clams10 = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
-          const fudco7 = E(E(myStockPurseP).getIssuer()).makeAmount(7);
+          const clams10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
+          const fudco7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
           const verifiedInviteP = E(allegedInvitePaymentP)
             .getBalance()
             .then(allegedInviteAmount => {
-              return E.resolve(Promise.all([clams10, fudco7])).then(terms => {
+              return E.resolve(Promise.all([clams10P, fudco7P])).then(terms => {
                 const [left, right] = terms;
                 return E(escrowExchangeInstallationP)
                   .checkAmount(allegedInviteAmount, { left, right })
@@ -82,15 +82,15 @@ function makeAliceMaker(E, host, log) {
 
           const verifiedInvitePaymentP = E.resolve(allegedInviteAmountP).then(
             allegedInviteAmount => {
-              const smackers10 = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
-              const yoyodyne7 = E(E(myStockPurseP).getIssuer()).makeAmount(7);
-              const coveredCallTerms = [
-                smackers10,
-                yoyodyne7,
+              const smackers10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
+              const yoyodyne7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
+              const coveredCallTermsP = [
+                smackers10P,
+                yoyodyne7P,
                 timerP,
                 'singularity',
               ];
-              return E.resolve(Promise.all(coveredCallTerms)).then(terms => {
+              return E.resolve(Promise.all(coveredCallTermsP)).then(terms => {
                 return E(coveredCallInstallationP)
                   .checkAmount(allegedInviteAmount, terms)
                   .then(_ => {

--- a/demo/contractHost/vat-bob.js
+++ b/demo/contractHost/vat-bob.js
@@ -54,11 +54,11 @@ function makeBobMaker(E, host, log) {
           log('++ bob.tradeWell starting');
           const terms = harden({ left: moneyNeededP, right: stockNeededP });
           const invitesP = E(escrowExchangeInstallationP).spawn(terms);
-          const aliceInviteP = invitesP.then(invites => invites.left);
-          const bobInviteP = invitesP.then(invites => invites.right);
+          const aliceInvitePaymentP = invitesP.then(invites => invites.left);
+          const bobInvitePaymentP = invitesP.then(invites => invites.right);
           const doneP = Promise.all([
-            E(alice).acceptInvite(aliceInviteP),
-            E(bob).acceptInvite(bobInviteP),
+            E(alice).acceptInvite(aliceInvitePaymentP),
+            E(bob).acceptInvite(bobInvitePaymentP),
           ]);
           doneP.then(
             _res => log('++ bob.tradeWell done'),

--- a/demo/contractHost/vat-bob.js
+++ b/demo/contractHost/vat-bob.js
@@ -76,13 +76,13 @@ function makeBobMaker(E, host, log) {
 
         offerAliceOption(alice) {
           log('++ bob.offerAliceOption starting');
-          const terms = harden([
-            escrowExchangeInstallationP,
-            moneyNeededP,
-            stockNeededP,
-            timerP,
-            'singularity',
-          ]);
+          const terms = harden({
+            escrowExchangeInstallation: escrowExchangeInstallationP,
+            money: moneyNeededP,
+            stock: stockNeededP,
+            timer: timerP,
+            deadline: 'singularity',
+          });
           const bobInviteP = E(coveredCallInstallationP).spawn(terms);
           const bobSeatP = E(host).redeem(bobInviteP);
           const stockPaymentP = E(myStockPurseP).withdraw(7);

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -30,24 +30,29 @@ function makeFredMaker(E, host, log) {
           const coveredCallTermsP = [dough10P, wonka7P, timerP, 'singularity'];
           const verifiedSaleInvitePaymentP = E(allegedSaleInvitePaymentP)
             .getBalance()
-            .then(balance => {
-              return E.resolve(fin55P).then(f55 =>
+            .then(allegedInviteAmount => {
+              return E.resolve(Promise.all(coveredCallTermsP)).then(
+                terms => {
                 E(escrowExchangeInstallationP)
-                  .checkPartialAmount(balance, f55)
-                  .then(coveredCallAmount =>
-                    E.resolve(Promise.all(coveredCallTermsP)).then(terms => {
-                      return E(coveredCallInstallationP)
-                        .checkAmount(coveredCallAmount, terms)
-                        .then(() => {
-                          return E(inviteIssuerP).getExclusive(
-                            balance,
-                            allegedSaleInvitePaymentP,
-                            'verified sale invite',
-                          );
-                        });
-                    }),
-                  ),
-              );
+                  .checkInstallation(allegedInviteAmount.quantity.installation)
+                  .then(validEscrowInstallationP => {
+                    return E(validEscrowInstallationP)
+                      .checkPartialAmount(allegedInviteAmount, terms, 'left')
+                      .then(coveredCallAmount => {
+                        return (
+                          E(coveredCallInstallationP)
+                            // TODO The  covered calls terms are different.
+                          .checkAmount(coveredCallAmount, terms)
+                          .then(() => {
+                            return E(inviteIssuerP).getExclusive(
+                              allegedInviteAmount,
+                              allegedSaleInvitePaymentP,
+                              'verified sale invite',
+                            );
+                          });
+                      });
+                  });
+              });
             });
 
           const saleSeatP = E(host).redeem(verifiedSaleInvitePaymentP);

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -19,69 +19,36 @@ function makeFredMaker(E, host, log) {
       myFinPurseP,
     ) {
       const inviteIssuerP = E(host).getInviteIssuer();
-      const inviteIssuerLabel = E(host).getInviteIssuerLabel();
+      const dough10 = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
+      const wonka7 = E(E(myStockPurseP).getIssuer()).makeAmount(7);
+      const fin55 = E(E(myFinPurseP).getIssuer()).makeAmount(55);
+
       const fred = harden({
         acceptOptionOffer(allegedSaleInvitePaymentP) {
           log('++ fred.acceptOptionOffer starting');
 
-          const dough10 = harden({
-            label: E(myMoneyPurseP).getIssuerLabel(),
-            quantity: 10,
-          });
-          const wonka7 = harden({
-            label: E(myStockPurseP).getIssuerLabel(),
-            quantity: 7,
-          });
-          const fin55 = harden({
-            label: E(myFinPurseP).getIssuerLabel(),
-            quantity: 55,
-          });
-
-          const allegedSaleAmountP = E(allegedSaleInvitePaymentP).getBalance();
-
-          const verifiedSaleInvitePaymentP = E.resolve(allegedSaleAmountP).then(
-            allegedSaleInviteAmount => {
-              const allegedOptionsInviteAmount =
-                allegedSaleInviteAmount.quantity.terms.right;
-
-              const optionsInviteAmount = harden({
-                label: inviteIssuerLabel,
-                quantity: {
-                  installation: coveredCallInstallationP,
-                  terms: [
-                    escrowExchangeInstallationP,
-                    dough10,
-                    wonka7,
-                    timerP,
-                    'singularity',
-                  ],
-                  seatIdentity:
-                    allegedOptionsInviteAmount.quantity.seatIdentity,
-                  seatDesc: 'holder',
-                },
-              });
-
-              const saleInviteAmountP = allComparable(
-                harden({
-                  label: inviteIssuerLabel,
-                  quantity: {
-                    installation: escrowExchangeInstallationP,
-                    terms: { left: fin55, right: optionsInviteAmount },
-                    seatIdentity: allegedSaleInviteAmount.quantity.seatIdentity,
-                    seatDesc: 'left',
-                  },
-                }),
+          const coveredCallTermsP = [dough10, wonka7, timerP, 'singularity'];
+          const verifiedSaleInvitePaymentP = E(allegedSaleInvitePaymentP)
+            .getBalance()
+            .then(balance => {
+              return E.resolve(fin55).then(f55 =>
+                E(escrowExchangeInstallationP)
+                  .checkPartialAmount(balance, f55)
+                  .then(coveredCallAmount =>
+                    E.resolve(Promise.all(coveredCallTermsP)).then(terms => {
+                      return E(coveredCallInstallationP)
+                        .checkAmount(coveredCallAmount, terms)
+                        .then(() => {
+                          return E(inviteIssuerP).getExclusive(
+                            balance,
+                            allegedSaleInvitePaymentP,
+                            'verified sale invite',
+                          );
+                        });
+                    }),
+                  ),
               );
-
-              return E.resolve(saleInviteAmountP).then(saleInviteAmount => {
-                return E(inviteIssuerP).getExclusive(
-                  saleInviteAmount,
-                  allegedSaleInvitePaymentP,
-                  'verified sale invite',
-                );
-              });
-            },
-          );
+            });
 
           const saleSeatP = E(host).redeem(verifiedSaleInvitePaymentP);
           const finPaymentP = E(myFinPurseP).withdraw(55);

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -19,37 +19,21 @@ function makeFredMaker(E, host, log) {
       myFinPurseP,
     ) {
       const inviteIssuerP = E(host).getInviteIssuer();
-      const inviteIssuerLabel = harden({
-        issuer: inviteIssuerP,
-        description: 'contract host',
-      });
-      const moneyIssuerP = E(myMoneyPurseP).getIssuer();
-      const stockIssuerP = E(myStockPurseP).getIssuer();
-      const finIssuerP = E(myFinPurseP).getIssuer();
-
+      const inviteIssuerLabel = E(host).getInviteIssuerLabel();
       const fred = harden({
         acceptOptionOffer(allegedSaleInvitePaymentP) {
           log('++ fred.acceptOptionOffer starting');
 
           const dough10 = harden({
-            label: {
-              issuer: moneyIssuerP,
-              description: 'dough',
-            },
+            label: E(myMoneyPurseP).getIssuerLabel(),
             quantity: 10,
           });
           const wonka7 = harden({
-            label: {
-              issuer: stockIssuerP,
-              description: 'wonka',
-            },
+            label: E(myStockPurseP).getIssuerLabel(),
             quantity: 7,
           });
           const fin55 = harden({
-            label: {
-              issuer: finIssuerP,
-              description: 'fins',
-            },
+            label: E(myFinPurseP).getIssuerLabel(),
             quantity: 55,
           });
 

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -19,19 +19,19 @@ function makeFredMaker(E, host, log) {
       myFinPurseP,
     ) {
       const inviteIssuerP = E(host).getInviteIssuer();
-      const dough10 = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
-      const wonka7 = E(E(myStockPurseP).getIssuer()).makeAmount(7);
-      const fin55 = E(E(myFinPurseP).getIssuer()).makeAmount(55);
+      const dough10P = E(E(myMoneyPurseP).getIssuer()).makeAmount(10);
+      const wonka7P = E(E(myStockPurseP).getIssuer()).makeAmount(7);
+      const fin55P = E(E(myFinPurseP).getIssuer()).makeAmount(55);
 
       const fred = harden({
         acceptOptionOffer(allegedSaleInvitePaymentP) {
           log('++ fred.acceptOptionOffer starting');
 
-          const coveredCallTermsP = [dough10, wonka7, timerP, 'singularity'];
+          const coveredCallTermsP = [dough10P, wonka7P, timerP, 'singularity'];
           const verifiedSaleInvitePaymentP = E(allegedSaleInvitePaymentP)
             .getBalance()
             .then(balance => {
-              return E.resolve(fin55).then(f55 =>
+              return E.resolve(fin55P).then(f55 =>
                 E(escrowExchangeInstallationP)
                   .checkPartialAmount(balance, f55)
                   .then(coveredCallAmount =>
@@ -64,7 +64,7 @@ function makeFredMaker(E, host, log) {
             // Fred bought the option. Now fred tries to exercise the option.
             const optionInvitePaymentP = E(optionInvitePurseP).withdrawAll();
             const optionSeatP = E(host).redeem(optionInvitePaymentP);
-            return E.resolve(allComparable(dough10)).then(d10 => {
+            return E.resolve(allComparable(dough10P)).then(d10 => {
               const doughPaymentP = E(myMoneyPurseP).withdraw(d10);
               E(optionSeatP).offer(doughPaymentP);
               return collect(

--- a/demo/contractHost/vat-fred.js
+++ b/demo/contractHost/vat-fred.js
@@ -31,27 +31,22 @@ function makeFredMaker(E, host, log) {
           const verifiedSaleInvitePaymentP = E(allegedSaleInvitePaymentP)
             .getBalance()
             .then(allegedInviteAmount => {
-              return E.resolve(Promise.all(coveredCallTermsP)).then(
-                terms => {
-                E(escrowExchangeInstallationP)
-                  .checkInstallation(allegedInviteAmount.quantity.installation)
-                  .then(validEscrowInstallationP => {
-                    return E(validEscrowInstallationP)
-                      .checkPartialAmount(allegedInviteAmount, terms, 'left')
-                      .then(coveredCallAmount => {
-                        return (
-                          E(coveredCallInstallationP)
-                            // TODO The  covered calls terms are different.
-                          .checkAmount(coveredCallAmount, terms)
-                          .then(() => {
-                            return E(inviteIssuerP).getExclusive(
-                              allegedInviteAmount,
-                              allegedSaleInvitePaymentP,
-                              'verified sale invite',
-                            );
-                          });
-                      });
-                  });
+              return E.resolve(allComparable(fin55P)).then(f55 => {
+                return E(escrowExchangeInstallationP)
+                  .checkPartialAmount(allegedInviteAmount, f55, 'left')
+                  .then(coveredCallAmount =>
+                    E.resolve(Promise.all(coveredCallTermsP)).then(terms => {
+                      return E(coveredCallInstallationP)
+                        .checkAmount(coveredCallAmount, terms)
+                        .then(() => {
+                          return E(inviteIssuerP).getExclusive(
+                            allegedInviteAmount,
+                            allegedSaleInvitePaymentP,
+                            'verified sale invite',
+                          );
+                        });
+                    }),
+                  );
               });
             });
 

--- a/demo/gallery/vat-alice.js
+++ b/demo/gallery/vat-alice.js
@@ -6,7 +6,7 @@ import harden from '@agoric/harden';
 import evaluate from '@agoric/evaluate';
 import { insist } from '../../util/insist';
 import { makeCollect, makeContractHost } from '../../core/contractHost';
-import { escrowExchangeSrc } from '../../core/escrow';
+import { escrowExchangeSrcs } from '../../core/escrow';
 
 let storedUseRight;
 let storedTransferRight;
@@ -19,7 +19,7 @@ function createSaleOffer(E, pixelPaymentP, gallery, dustPurseP, collect, log) {
     const terms = harden({ left: dustAmount, right: pixelAmount });
     const contractHost = makeContractHost(E, evaluate);
     const escrowExchangeInstallationP = E(contractHost).install(
-      escrowExchangeSrc,
+      escrowExchangeSrcs,
     );
     const { left: buyerInviteP, right: sellerInviteP } = await E(
       escrowExchangeInstallationP,

--- a/demo/pixel-demo/bootstrap.js
+++ b/demo/pixel-demo/bootstrap.js
@@ -2,8 +2,8 @@
 
 import harden from '@agoric/harden';
 
-import { escrowExchangeSrc } from '../../core/escrow';
-import { coveredCallSrc } from '../../core/coveredCall';
+import { escrowExchangeSrcs } from '../../core/escrow';
+import { coveredCallSrcs } from '../../core/coveredCall';
 import { makeWholePixelList } from '../../more/pixels/types/pixelList';
 
 function build(E, log) {
@@ -90,8 +90,8 @@ function build(E, log) {
     aliceMaker,
     bobMaker,
   ) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('moola');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000);
@@ -160,8 +160,8 @@ function build(E, log) {
   }
 
   function betterContractTestBobFirst(host, mint, aliceMaker, bobMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('clams');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000, 'aliceMainMoney');
@@ -233,8 +233,8 @@ function build(E, log) {
   }
 
   function coveredCallTest(host, mint, aliceMaker, bobMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const moneyMintP = E(mint).makeMint('smackers');
     const aliceMoneyPurseP = E(moneyMintP).mint(1000, 'aliceMainMoney');
@@ -306,8 +306,8 @@ function build(E, log) {
   }
 
   function coveredCallSaleTest(host, mint, aliceMaker, bobMaker, fredMaker) {
-    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrc);
-    const coveredCallInstallationP = E(host).install(coveredCallSrc);
+    const escrowExchangeInstallationP = E(host).install(escrowExchangeSrcs);
+    const coveredCallInstallationP = E(host).install(coveredCallSrcs);
 
     const doughMintP = E(mint).makeMint('dough');
     const aliceDoughPurseP = E(doughMintP).mint(1000, 'aliceDough');

--- a/demo/pixel-demo/vat-alice.js
+++ b/demo/pixel-demo/vat-alice.js
@@ -139,13 +139,13 @@ function makeAliceMaker(E, host, log) {
                   label: inviteIssuerLabel,
                   quantity: {
                     installation: coveredCallInstallationP,
-                    terms: [
-                      escrowExchangeInstallationP,
-                      smackers10,
-                      pixel1x1,
-                      timerP,
-                      'singularity',
-                    ],
+                    terms: {
+                      escrowExchangeInstallation: escrowExchangeInstallationP,
+                      money: smackers10,
+                      stock: pixel1x1,
+                      timer: timerP,
+                      deadline: 'singularity',
+                    },
                     seatIdentity: allegedInviteAmount.quantity.seatIdentity,
                     seatDesc: 'holder',
                   },

--- a/demo/pixel-demo/vat-bob.js
+++ b/demo/pixel-demo/vat-bob.js
@@ -94,13 +94,13 @@ function makeBobMaker(E, host, log) {
         offerAliceOption(alice) {
           log('++ bob.offerAliceOption starting');
 
-          const terms = harden([
-            escrowExchangeInstallationP,
-            moneyNeededP,
-            pixelsNeededP,
-            timerP,
-            'singularity',
-          ]);
+          const terms = harden({
+            escrowExchangeInstallation: escrowExchangeInstallationP,
+            money: moneyNeededP,
+            stock: pixelsNeededP,
+            timer: timerP,
+            deadline: 'singularity',
+          });
           const bobInviteP = E(coveredCallInstallationP).spawn(terms);
           const bobSeatP = E(host).redeem(bobInviteP);
           return E.resolve(pixelsNeededP).then(pixelsNeeded => {

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -13,7 +13,7 @@ import { insistPixel, isEqual as isEqualPixel } from './types/pixel';
 import { makeMintController } from './pixelMintController';
 import { makeLruQueue } from './lruQueue';
 
-import { escrowExchangeSrc } from '../../core/escrow';
+import { escrowExchangeSrcs } from '../../core/escrow';
 import { makeContractHost, makeCollect } from '../../core/contractHost';
 
 function mockStateChangeHandler(_newState) {
@@ -311,7 +311,7 @@ export function makeGallery(
       const terms = harden({ left: dustAmount, right: pixelAmount });
       const contractHost = makeContractHost(E, evaluate);
       const escrowExchangeInstallationP = await E(contractHost).install(
-        escrowExchangeSrc,
+        escrowExchangeSrcs,
       );
       const { left: galleryInviteP, right: userInviteP } = await E(
         escrowExchangeInstallationP,
@@ -350,7 +350,7 @@ export function makeGallery(
       const terms = harden({ left: dustAmount, right: pixelAmount });
       const contractHost = makeContractHost(E, evaluate);
       const escrowExchangeInstallationP = E(contractHost).install(
-        escrowExchangeSrc,
+        escrowExchangeSrcs,
       );
       // order switch compared to as in sellToGallery
       const { left: userInviteP, right: galleryInviteP } = await E(

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,10 @@
       }
     },
     "@agoric/eventual-send": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.1.10.tgz",
-      "integrity": "sha512-g1lmfayl28twcK8kB0VktRzk9x8g6YG2uwftFluYYfmomBdrO4DdOQzM0BoEeQquvzETBz+9d1bzfHbw9ZAGUg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.2.0.tgz",
+      "integrity": "sha512-r4nT3mk0zj5iXebI819XHO1pj5HNGwTHLqnQLarXXdOXym4keUqf07pmZ2L/8joniR0rjC5GlvHuc7o551EWUA==",
+      "dev": true
     },
     "@agoric/harden": {
       "version": "0.0.4",
@@ -81,6 +82,7 @@
         "@agoric/acorn-infix-bang": "0.0.4",
         "@agoric/default-evaluate-options": "^0.1.0",
         "@agoric/evaluate": "^1.1.0",
+        "@agoric/eventual-send": "^0.2.0",
         "@agoric/harden": "^0.0.4",
         "@agoric/marshal": "0.0.1",
         "@agoric/nat": "^2.0.0",
@@ -91,25 +93,6 @@
         "yargs": "^13.1.0"
       },
       "dependencies": {
-        "@agoric/default-evaluate-options": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.1.0.tgz",
-          "integrity": "sha512-9yloipU26stjHC5fKTDIe3JUb7jHPNg0bfSxHye27rMIZgl+KcrDzjs5bdhrXIYZwYzert6RcCfQzkJMAWDtDA==",
-          "dev": true,
-          "requires": {
-            "@agoric/babel-parser": "^7.5.0",
-            "@agoric/eventual-send": "^0.1.11",
-            "@agoric/transform-bang": "^0.3.1",
-            "@babel/generator": "^7.5.5",
-            "esm": "^3.2.5"
-          }
-        },
-        "@agoric/eventual-send": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/@agoric/eventual-send/-/eventual-send-0.1.11.tgz",
-          "integrity": "sha512-iQ8Ley6LBErUIYH5ZetU3IeyzwrXsoru5LLvAY0vc2pVlIMUZ0wRGzaWIEcVWSRKUDh5/n1LJXz/bVJ7d1MHZg==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -119,9 +102,10 @@
       }
     },
     "@agoric/transform-bang": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@agoric/transform-bang/-/transform-bang-0.3.1.tgz",
-      "integrity": "sha512-Qhbf71pM3n/o/VSmsL38n9Yk8P0BTi+/UuXbySo9hmzWTLofHeUU1luI/CrRUtz6z6Fqt5JvAhiMIxcJdAthsg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@agoric/transform-bang/-/transform-bang-0.3.3.tgz",
+      "integrity": "sha512-3UkAooZ/Y4tqgvWNyW5mT1lnFmXklyb4wirB7rCtkp60WQtinfsevl6uLtYI2Q8cxgdbSwLr11v/HfuPNdWNBA==",
+      "dev": true,
       "requires": {
         "@agoric/harden": "0.0.4",
         "esm": "^3.2.5"

--- a/test/core/bootstrap.js
+++ b/test/core/bootstrap.js
@@ -1,0 +1,174 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { escrowExchangeSrcs } from '../../core/escrow';
+import { makeUniAssayMaker } from '../../core/assays';
+import { makeBasicMintController } from '../../core/mintController';
+import { insist } from '../../util/insist';
+import { makeMint } from '../../core/issuers';
+import { allComparable } from '../../util/sameStructure';
+
+function build(E, log) {
+  function testEscrowServiceMismatches(host, randMintP, artMintP) {
+    log('starting testEscrowServiceCheckMismatches');
+    const installationP = E(host).install(escrowExchangeSrcs);
+    const randAmountP = E(E(randMintP).getIssuer()).makeAmount(3);
+    const blueBoyAmount = E(E(artMintP).getIssuer()).makeAmount('Blue Boy');
+    const blueGirlAmount = E(E(artMintP).getIssuer()).makeAmount('Blue Girl');
+    const actualTermsP = harden({ left: randAmountP, right: blueBoyAmount });
+    const allegedTermsP = harden({ left: randAmountP, right: blueGirlAmount });
+    const invitesP = E(installationP).spawn(actualTermsP);
+    const result = invitesP.then(invites => {
+      return E(invites.left)
+        .getBalance()
+        .then(allegedLeftInviteAmount => {
+          return allComparable(allegedTermsP).then(terms => {
+            return E(installationP).checkAmount(allegedLeftInviteAmount, terms);
+          });
+        });
+    });
+    result.then(
+      r => {
+        log(`didn't expect successful check ${r}`);
+      },
+      r => {
+        log(`expected unsuccessful check ${r}`);
+      },
+    );
+  }
+
+  function testEscrowServiceSuccess(host, randMintP, artMintP) {
+    log('starting testEscrowServiceSuccess');
+    const installationP = E(host).install(escrowExchangeSrcs);
+    const randAmountP = E(E(randMintP).getIssuer()).makeAmount(3);
+    const screamAmountP = E(E(artMintP).getIssuer()).makeAmount('The Scream');
+    const termsP = harden({ left: randAmountP, right: screamAmountP });
+    const invitesP = E(installationP).spawn(termsP);
+    const result = invitesP.then(invites => {
+      return E(invites.left)
+        .getBalance()
+        .then(allegedLeftInviteAmount => {
+          return allComparable(termsP).then(terms => {
+            return E(installationP).checkAmount(allegedLeftInviteAmount, terms);
+          });
+        });
+    });
+    result.then(r => {
+      insist(r)`\
+expected successful check ${result}`;
+    });
+  }
+
+  function testEscrowCheckPartialWrongPrice(host, randMintP, artMintP) {
+    log('starting testEscrowServiceCheckPartial wrong price');
+    const installationP = E(host).install(escrowExchangeSrcs);
+    const randAmountP = E(E(randMintP).getIssuer()).makeAmount(3);
+    const otherRandAmountP = E(E(randMintP).getIssuer()).makeAmount(5);
+    const blueBoyAmount = E(E(artMintP).getIssuer()).makeAmount('Blue Boy');
+    const actualTermsP = harden({ left: randAmountP, right: blueBoyAmount });
+    const allegedTermsP = harden({
+      left: otherRandAmountP,
+      right: blueBoyAmount,
+    });
+    const invitesP = E(installationP).spawn(actualTermsP);
+    const result = invitesP.then(invites => {
+      return E(invites.left)
+        .getBalance()
+        .then(allegedLeftInviteAmount => {
+          return allComparable(allegedTermsP).then(terms => {
+            return E(installationP).checkPartialAmount(
+              allegedLeftInviteAmount,
+              terms,
+              'left',
+            );
+          });
+        });
+    });
+
+    result.then(
+      r => {
+        log(`didn't expect successful check ${r}`);
+      },
+      r => {
+        log(`expected wrong price ${r}`);
+      },
+    );
+  }
+  function testEscrowCheckPartialWrongSeat(host, randMintP, artMintP) {
+    log('starting testEscrowServiceCheckPartial wrong seat');
+    const installationP = E(host).install(escrowExchangeSrcs);
+    const randAmountP = E(E(randMintP).getIssuer()).makeAmount(3);
+    const blueBoyAmount = E(E(artMintP).getIssuer()).makeAmount('Blue Boy');
+    const actualTermsP = harden({ left: randAmountP, right: blueBoyAmount });
+    const invitesP = E(installationP).spawn(actualTermsP);
+    const result = invitesP.then(invites => {
+      return E(invites.left)
+        .getBalance()
+        .then(allegedLeftInviteAmount => {
+          return allComparable(actualTermsP).then(terms => {
+            return E(installationP).checkPartialAmount(
+              allegedLeftInviteAmount,
+              terms,
+              'right',
+            );
+          });
+        });
+    });
+
+    result.then(
+      r => {
+        log(`didn't expect successful check ${r}`);
+      },
+      r => {
+        log(`expected wrong side ${r}`);
+      },
+    );
+  }
+
+  const obj0 = {
+    async bootstrap(argv, vats) {
+      const host = await E(vats.host).makeHost();
+      const randMintP = E(vats.mint).makeMint('rand');
+      const artMintP = makeMint(
+        'art',
+        makeBasicMintController,
+        makeUniAssayMaker(),
+      );
+      switch (argv[0]) {
+        case 'escrow misMatches': {
+          return testEscrowServiceMismatches(host, randMintP, artMintP);
+        }
+        case 'escrow matches': {
+          return testEscrowServiceSuccess(host, randMintP, artMintP);
+        }
+        case 'escrow partial seat': {
+          return testEscrowCheckPartialWrongSeat(host, randMintP, artMintP);
+        }
+        case 'escrow partial price': {
+          return testEscrowCheckPartialWrongPrice(host, randMintP, artMintP);
+        }
+        default: {
+          throw new Error(`unrecognized argument value ${argv[0]}`);
+        }
+      }
+    },
+  };
+  return harden(obj0);
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  log(`=> setup called`);
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/test/core/test-escrow.js
+++ b/test/core/test-escrow.js
@@ -48,7 +48,7 @@ test('escrow check misMatches', async t => {
 const escrowCheckPartialWrongPriceGolden = [
   '=> setup called',
   'starting testEscrowServiceCheckPartial wrong price',
-  'expected wrong price Error: Escrow checkPartialAmount: different at top.left.quantity: ((a number)) vs ((a number))\nSee console for error data.',
+  'expected wrong price Error: Escrow checkPartialAmount seat: different at top.quantity: ((a number)) vs ((a number))\nSee console for error data.',
 ];
 
 test('escrow check partial misMatches w/SES', async t => {
@@ -63,10 +63,28 @@ test('escrow check partial misMatches', async t => {
   t.end();
 });
 
+const escrowCheckPartialWrongStockGolden = [
+  '=> setup called',
+  'starting testEscrowServiceCheckPartial wrong stock',
+  'expected wrong stock Error: Escrow checkPartialAmount seat: different at top.quantity: ((a string)) vs ((a string))\nSee console for error data.',
+];
+
+test('escrow check partial misMatches w/SES', async t => {
+  const dump = await main(true, 'test/core', ['escrow partial stock']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongStockGolden);
+  t.end();
+});
+
+test('escrow check partial misMatches', async t => {
+  const dump = await main(false, 'test/core', ['escrow partial stock']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongStockGolden);
+  t.end();
+});
+
 const escrowCheckPartialWrongSeatGolden = [
   '=> setup called',
   'starting testEscrowServiceCheckPartial wrong seat',
-  'expected wrong side Error: undefined: different at top: ((a string)) vs ((a string))\nSee console for error data.',
+  'expected wrong side Error: Escrow checkPartialAmount seat: label not found on right at top: ((a object)) vs ((a object))\nSee console for error data.',
 ];
 
 test('escrow check partial wrong seat w/SES', async t => {

--- a/test/core/test-escrow.js
+++ b/test/core/test-escrow.js
@@ -1,0 +1,82 @@
+import { test } from 'tape-promise/tape';
+import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
+
+async function main(withSES, basedir, argv) {
+  const config = await loadBasedir(basedir);
+  const ldSrcPath = require.resolve(
+    '@agoric/swingset-vat/src/devices/loopbox-src',
+  );
+  config.devices = [['loopbox', ldSrcPath, {}]];
+
+  const controller = await buildVatController(config, withSES, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+const escrowGolden = ['=> setup called', 'starting testEscrowServiceSuccess'];
+
+test('escrow checkAmount w/SES', async t => {
+  const dump = await main(true, 'test/core', ['escrow matches']);
+  t.deepEquals(dump.log, escrowGolden);
+  t.end();
+});
+
+test('escrow checkAmount', async t => {
+  const dump = await main(false, 'test/core', ['escrow matches']);
+  t.deepEquals(dump.log, escrowGolden);
+  t.end();
+});
+
+const escrowMismatchGolden = [
+  '=> setup called',
+  'starting testEscrowServiceCheckMismatches',
+  'expected unsuccessful check Error: Escrow checkAmount: different at top.right.quantity: ((a string)) vs ((a string))\nSee console for error data.',
+];
+
+test('escrow check misMatches w/SES', async t => {
+  const dump = await main(true, 'test/core', ['escrow misMatches']);
+  t.deepEquals(dump.log, escrowMismatchGolden);
+  t.end();
+});
+
+test('escrow check misMatches', async t => {
+  const dump = await main(false, 'test/core', ['escrow misMatches']);
+  t.deepEquals(dump.log, escrowMismatchGolden);
+  t.end();
+});
+
+const escrowCheckPartialWrongPriceGolden = [
+  '=> setup called',
+  'starting testEscrowServiceCheckPartial wrong price',
+  'expected wrong price Error: Escrow checkPartialAmount: different at top.left.quantity: ((a number)) vs ((a number))\nSee console for error data.',
+];
+
+test('escrow check partial misMatches w/SES', async t => {
+  const dump = await main(true, 'test/core', ['escrow partial price']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongPriceGolden);
+  t.end();
+});
+
+test('escrow check partial misMatches', async t => {
+  const dump = await main(false, 'test/core', ['escrow partial price']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongPriceGolden);
+  t.end();
+});
+
+const escrowCheckPartialWrongSeatGolden = [
+  '=> setup called',
+  'starting testEscrowServiceCheckPartial wrong seat',
+  'expected wrong side Error: undefined: different at top: ((a string)) vs ((a string))\nSee console for error data.',
+];
+
+test('escrow check partial wrong seat w/SES', async t => {
+  const dump = await main(true, 'test/core', ['escrow partial seat']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongSeatGolden);
+  t.end();
+});
+
+test('escrow check partial wrong seat', async t => {
+  const dump = await main(false, 'test/core', ['escrow partial seat']);
+  t.deepEquals(dump.log, escrowCheckPartialWrongSeatGolden);
+  t.end();
+});

--- a/test/core/vat-host.js
+++ b/test/core/vat-host.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2018 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+import evaluate from '@agoric/evaluate';
+
+import { makeContractHost } from '../../core/contractHost';
+
+function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E =>
+      harden({
+        makeHost() {
+          return harden(makeContractHost(E, evaluate));
+        },
+      }),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/test/core/vat-mint.js
+++ b/test/core/vat-mint.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+import { makeMint } from '../../core/issuers';
+
+function build(_E, _log) {
+  return harden({ makeMint });
+}
+harden(build);
+
+function setup(syscall, state, helpers) {
+  function log(...args) {
+    helpers.log(...args);
+    console.log(...args);
+  }
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, log),
+    helpers.vatID,
+  );
+}
+export default harden(setup);

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -110,8 +110,8 @@ const contractCoveredCallGolden = [
   '++ bob.offerAliceOption starting',
   '++ alice.acceptOptionDirectly starting',
   'Pretend singularity never happens',
-  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
-  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":{"escrowExchangeInstallation":{},"money":{"label":{"issuer":{},"description":"smackers"},"quantity":10},"stock":{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},"timer":{},"deadline":"singularity"},"seatIdentity":{},"seatDesc":"holder"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":{"escrowExchangeInstallation":{},"money":{"label":{"issuer":{},"description":"smackers"},"quantity":10},"stock":{"label":{"issuer":{},"description":"yoyodyne"},"quantity":7},"timer":{},"deadline":"singularity"},"seatIdentity":{},"seatDesc":"holder"}}',
   'alice option wins: {"label":{"issuer":{},"description":"yoyodyne"},"quantity":7} refs: null',
   'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null',
   '++ bob.offerAliceOption done',
@@ -143,7 +143,7 @@ const contractCoveredCallSaleGolden = [
   '++ fred.acceptOptionOffer starting',
   'Pretend singularity never happens',
   'alice options sale wins: {"label":{"issuer":{},"description":"fins"},"quantity":55} refs: null',
-  'fred buys escrowed option wins: {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"dough"},"quantity":10},{"label":{"issuer":{},"description":"wonka"},"quantity":7},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}} refs: null',
+  'fred buys escrowed option wins: {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":{"escrowExchangeInstallation":{},"money":{"label":{"issuer":{},"description":"dough"},"quantity":10},"stock":{"label":{"issuer":{},"description":"wonka"},"quantity":7},"timer":{},"deadline":"singularity"},"seatIdentity":{},"seatDesc":"holder"}} refs: null',
   'fred exercises option, buying stock wins: {"label":{"issuer":{},"description":"wonka"},"quantity":7} refs: null',
   'bob option wins: {"label":{"issuer":{},"description":"dough"},"quantity":10} refs: null',
   '++ alice.acceptOptionForFred done',
@@ -166,7 +166,7 @@ test('run contractHost Demo --covered-call-sale with SES', async t => {
   t.end();
 });
 
-test('run contractHost Demo --covered-call-sale without SES', async t => {
+test.only('run contractHost Demo --covered-call-sale without SES', async t => {
   const dump = await main(false, 'demo/contractHost', ['covered-call-sale']);
   t.deepEquals(dump.log, contractCoveredCallSaleGolden);
   t.end();
@@ -300,8 +300,8 @@ const contractCoveredCallGoldenPixel = [
   '++ bob.offerAliceOption starting',
   '++ alice.acceptOptionDirectly starting',
   'Pretend singularity never happens',
-  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
-  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":[{},{"label":{"issuer":{},"description":"smackers"},"quantity":10},{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},{},"singularity"],"seatIdentity":{},"seatDesc":"holder"}}',
+  'alice invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":{"escrowExchangeInstallation":{},"money":{"label":{"issuer":{},"description":"smackers"},"quantity":10},"stock":{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},"timer":{},"deadline":"singularity"},"seatIdentity":{},"seatDesc":"holder"}}',
+  'verified invite balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":{"escrowExchangeInstallation":{},"money":{"label":{"issuer":{},"description":"smackers"},"quantity":10},"stock":{"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]},"timer":{},"deadline":"singularity"},"seatIdentity":{},"seatDesc":"holder"}}',
   'alice option wins: {"label":{"issuer":{},"description":"pixelList"},"quantity":[{"x":1,"y":1}]} refs: null',
   'bob option wins: {"label":{"issuer":{},"description":"smackers"},"quantity":10} refs: null',
   '++ bob.offerAliceOption done',

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 
 async function main(withSES, basedir, argv) {
   const config = await loadBasedir(basedir);
@@ -166,7 +166,7 @@ test('run contractHost Demo --covered-call-sale with SES', async t => {
   t.end();
 });
 
-test('run contractHost Demo --covered-call-sale without SES', async t => {
+test.only('run contractHost Demo --covered-call-sale without SES', async t => {
   const dump = await main(false, 'demo/contractHost', ['covered-call-sale']);
   t.deepEquals(dump.log, contractCoveredCallSaleGolden);
   t.end();

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -38,14 +38,14 @@ test('run contractHost Demo --mint without SES', async t => {
 const contractTrivialGolden = [
   '=> setup called',
   'starting trivialContractTest',
-  'Does source {"start":"(terms, inviteM...\', 8);\\n      } "} match? true',
+  'Does source match? true',
   'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":"foo terms","seatIdentity":{},"seatDesc":"foo"}}',
   '++ eightP resolved to 8 (should be 8)',
   '++ DONE',
   'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":null}',
 ];
 
-test.only('run contractHost Demo --trivial with SES', async t => {
+test('run contractHost Demo --trivial with SES', async t => {
   const dump = await main(true, 'demo/contractHost', ['trivial']);
   t.deepEquals(dump.log, contractTrivialGolden);
   t.end();

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -166,7 +166,7 @@ test('run contractHost Demo --covered-call-sale with SES', async t => {
   t.end();
 });
 
-test.only('run contractHost Demo --covered-call-sale without SES', async t => {
+test('run contractHost Demo --covered-call-sale without SES', async t => {
   const dump = await main(false, 'demo/contractHost', ['covered-call-sale']);
   t.deepEquals(dump.log, contractCoveredCallSaleGolden);
   t.end();

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
+import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 
 async function main(withSES, basedir, argv) {
   const config = await loadBasedir(basedir);
@@ -166,7 +166,7 @@ test('run contractHost Demo --covered-call-sale with SES', async t => {
   t.end();
 });
 
-test.only('run contractHost Demo --covered-call-sale without SES', async t => {
+test('run contractHost Demo --covered-call-sale without SES', async t => {
   const dump = await main(false, 'demo/contractHost', ['covered-call-sale']);
   t.deepEquals(dump.log, contractCoveredCallSaleGolden);
   t.end();

--- a/test/demo/test-demos.js
+++ b/test/demo/test-demos.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 
 async function main(withSES, basedir, argv) {
   const config = await loadBasedir(basedir);
@@ -38,14 +38,14 @@ test('run contractHost Demo --mint without SES', async t => {
 const contractTrivialGolden = [
   '=> setup called',
   'starting trivialContractTest',
-  'Does contract source match? true',
+  'Does source {"start":"(terms, inviteM...\', 8);\\n      } "} match? true',
   'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":{"installation":{},"terms":"foo terms","seatIdentity":{},"seatDesc":"foo"}}',
   '++ eightP resolved to 8 (should be 8)',
   '++ DONE',
   'foo balance {"label":{"issuer":{},"description":"contract host"},"quantity":null}',
 ];
 
-test('run contractHost Demo --trivial with SES', async t => {
+test.only('run contractHost Demo --trivial with SES', async t => {
   const dump = await main(true, 'demo/contractHost', ['trivial']);
   t.deepEquals(dump.log, contractTrivialGolden);
   t.end();


### PR DESCRIPTION

refactor contractHost to simplify verification of invites.  …
Also add a helper for building amounts.

I wonder whether there's a way to move the added complexity of defining
contracts into the contractHost.

const escrowExchangeThunk = () =>
  harden({
    start(terms, inviteMaker) {

vs.

function escrowExchange(terms, inviteMaker) {