### PR TITLE
swingset should only be a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "@agoric/harden": "^0.0.4",
     "@agoric/marshal": "^0.0.1",
     "@agoric/nat": "^2.0.1",
-    "@agoric/swingset-vat": "^0.0.16",
     "ses": "^0.5.3"
   },
   "devDependencies": {
+    "@agoric/swingset-vat": "^0.0.16",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.3.0",


### PR DESCRIPTION
I couldn't find any reason why ERTP should depend on swingset for purposes other than testing.

However, I wan't able to run `npm test` either before or after this change for dependency problems that seem unrelated:

```
$ npm test

> @agoric/ertp@0.0.9-dev.1 test /Users/markmiller/src/ongithub/agoric/ERTP
> tape -r esm 'test/**/test*.js' | tap-spec

/Users/markmiller/src/ongithub/agoric/ERTP/node_modules/@agoric/swingset-vat/src/controller.js:1
Error: Cannot find module './kvstore'
Require stack:
- /Users/markmiller/src/ongithub/agoric/ERTP/node_modules/@agoric/swingset-vat/src/controller.js
- /Users/markmiller/src/ongithub/agoric/ERTP/node_modules/@agoric/swingset-vat/src/index.js
- /Users/markmiller/src/ongithub/agoric/ERTP/node_modules/@agoric/swingset-vat/src/main.js
- /Users/markmiller/src/ongithub/agoric/ERTP/test/demo/test-demos.js
- /Users/markmiller/src/ongithub/agoric/ERTP/node_modules/tape/bin/tape
    at Object.<anonymous> (/Users/markmiller/src/ongithub/agoric/ERTP/node_modules/@agoric/swingset-vat/src/controller.js:1)


npm ERR! Test failed.  See above for more details.
```