### PR TITLE
remove calls to makeContractHost outside of long-lived host vat

### DIFF
--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -1,12 +1,13 @@
 import Nat from '@agoric/nat';
 import harden from '@agoric/harden';
-import evaluate from '@agoric/evaluate';
 
 import {
   makeCompoundPixelAssayMaker,
   makeTransferRightPixelAssayMaker,
   makeUseRightPixelAssayMaker,
 } from './pixelAssays';
+import { makeCollect } from '../../core/contractHost';
+
 import { makeMint } from '../../core/issuers';
 import { makeWholePixelList, insistPixelList } from './types/pixelList';
 import { insistPixel, isEqual as isEqualPixel } from './types/pixel';
@@ -14,7 +15,6 @@ import { makeMintController } from './pixelMintController';
 import { makeLruQueue } from './lruQueue';
 
 import { escrowExchangeSrcs } from '../../core/escrow';
-import { makeContractHost, makeCollect } from '../../core/contractHost';
 
 function mockStateChangeHandler(_newState) {
   // does nothing
@@ -23,6 +23,7 @@ function mockStateChangeHandler(_newState) {
 export function makeGallery(
   E,
   log,
+  contractHost,
   stateChangeHandler = mockStateChangeHandler,
   canvasSize = 10,
 ) {
@@ -52,6 +53,7 @@ export function makeGallery(
     }
     return randomColor;
   }
+  const collect = makeCollect(E, log);
 
   function makeRandomData() {
     const pixels = [];
@@ -97,7 +99,6 @@ export function makeGallery(
   }
 
   // START ERTP
-  const collect = makeCollect(E, log);
 
   const makePixelListAssay = makeCompoundPixelAssayMaker(canvasSize);
   const makeTransferAssay = makeTransferRightPixelAssayMaker(canvasSize);
@@ -313,7 +314,6 @@ export function makeGallery(
       );
       // dustPurse is dropped
       const terms = harden({ left: dustAmount, right: pixelAmount });
-      const contractHost = makeContractHost(E, evaluate);
       const escrowExchangeInstallationP = await E(contractHost).install(
         escrowExchangeSrcs,
       );
@@ -352,7 +352,6 @@ export function makeGallery(
       // the left will have to provide dust, right will have to
       // provide pixels. Left is the user, right is the gallery
       const terms = harden({ left: dustAmount, right: pixelAmount });
-      const contractHost = makeContractHost(E, evaluate);
       const escrowExchangeInstallationP = E(contractHost).install(
         escrowExchangeSrcs,
       );

--- a/test/swingsetTests/gallery/bootstrap.js
+++ b/test/swingsetTests/gallery/bootstrap.js
@@ -68,49 +68,58 @@ function build(E, log) {
         // does nothing in this test
       }
 
+      async function makeStartingObjs() {
+        const host = await E(vats.host).makeHost();
+        const aliceMaker = await E(vats.alice).makeAliceMaker(host);
+        const bobMaker = await E(vats.bob).makeBobMaker(host);
+        const gallery = await makeGallery(
+          E,
+          log,
+          host,
+          stateChangeHandler,
+          canvasSize,
+        );
+        return {
+          host,
+          aliceMaker,
+          bobMaker,
+          gallery,
+        };
+      }
+
       switch (argv[0]) {
         case 'tapFaucet': {
           log('starting tapFaucet');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
           log('alice is made');
+          const { aliceMaker, gallery } = await makeStartingObjs();
           return testTapFaucet(aliceMaker, gallery);
         }
         case 'aliceChangesColor': {
           log('starting aliceChangesColor');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
           log('alice is made');
+          const { aliceMaker, gallery } = await makeStartingObjs();
           return testAliceChangesColor(aliceMaker, gallery);
         }
         case 'aliceSendsOnlyUseRight': {
           log('starting aliceSendsOnlyUseRight');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const bobMaker = await E(vats.bob).makeBobMaker();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
           log('alice is made');
+          const { aliceMaker, bobMaker, gallery } = await makeStartingObjs();
           return testAliceSendsOnlyUseRight(aliceMaker, bobMaker, gallery);
         }
         case 'galleryRevokes': {
           log('starting galleryRevokes');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const bobMaker = await E(vats.bob).makeBobMaker();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
+          const { aliceMaker, bobMaker, gallery } = await makeStartingObjs();
           return testGalleryRevokes(aliceMaker, bobMaker, gallery);
         }
         case 'aliceSellsAndBuys': {
           log('starting aliceSellsAndBuys');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const bobMaker = await E(vats.bob).makeBobMaker();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
+          const { aliceMaker, bobMaker, gallery } = await makeStartingObjs();
           return testAliceSellsAndBuys(aliceMaker, bobMaker, gallery);
         }
         case 'aliceSellsToBob': {
           log('starting aliceSellsToBob');
-          const aliceMaker = await E(vats.alice).makeAliceMaker();
-          const bobMaker = await E(vats.bob).makeBobMaker();
+          const { aliceMaker, bobMaker, gallery } = await makeStartingObjs();
           const handoffSvc = await E(vats.handoff).makeHandoffService();
-          const gallery = makeGallery(E, log, stateChangeHandler, canvasSize);
           return testAliceSellsToBob(aliceMaker, bobMaker, gallery, handoffSvc);
         }
         default: {


### PR DESCRIPTION
This PR makes the gallery rely on a long-lived contract host in vat-host.js rather than calling `makeContractHost`. 

In making this change, I noticed that it might be a good idea to extract the functionality for creating the starting objects for tests, so I did that. Otherwise, it was too easy to accidentally change things in one line and not another. 

By moving `createSaleOffer` to be inside the `make` function for Alice, I was able to refactor it down to only two parameters.  

Closes #45 