### PR TITLE
Repair chainmail Files

### DIFF
--- a/core/assays.chainmail
+++ b/core/assays.chainmail
@@ -15,8 +15,11 @@ struct Amount (Quantity, Label) {
  * strings naming a particular right, or an arbitrary object that sensibly
  * represents the rights at issue. All Amounts made by the same Assay have the
  * same label.
+ *
+ * Quantity must be Comparable. (This IDL doesn't yet provide a way to specify
+ * subtype relationships for structs.)
  */
-struct Quantity /* extends (Comparable) */ {
+struct Quantity {
 }
 
 /**
@@ -96,8 +99,13 @@ struct Label {
   description :Description;
 }
 
-/** Human-readable description of a kind of rights. */
-struct Description /* extends (Comparable) */ {
+/**
+ * Human-readable description of a kind of rights.
+ *
+ * The Descriptions must be Comparables. (This IDL doesn't yet provide a way to
+ * specify subtype relationships for structs.)
+ */
+struct Description {
 }
 
 /**

--- a/core/assays.chainmail
+++ b/core/assays.chainmail
@@ -83,7 +83,7 @@ interface Assay (Amount (Quantity, Label)) {
    * in rightAmount. If leftAmount doesn't include rightAmout, throw an error.
    */
   without(leftAmount :Amount, rightAmount :Amount) -> (Amount);
-};
+}
 
 /**
  * The label for an amount identifies the issuer, and includes a description of

--- a/core/assays.chainmail
+++ b/core/assays.chainmail
@@ -16,7 +16,7 @@ struct Amount (Quantity, Label) {
  * represents the rights at issue. All Amounts made by the same Assay have the
  * same label.
  */
-struct Quantity extends (Comparable) {
+struct Quantity /* extends (Comparable) */ {
 }
 
 /**
@@ -97,7 +97,7 @@ struct Label {
 }
 
 /** Human-readable description of a kind of rights. */
-struct Description extends (Comparable) {
+struct Description /* extends (Comparable) */ {
 }
 
 /**

--- a/core/contractHost.chainmail
+++ b/core/contractHost.chainmail
@@ -52,7 +52,7 @@ interface Installation {
    * Create a new InviteMaker, then call the Contract's start() method and
    * return its results. The results are often a collection of seat invitations
    * for the seats in the contract, but see coveredCall for an exception.
-   *
+   */
   spawn(terms :Terms) -> (invites :Object);
 
  /**

--- a/core/contractHost.chainmail
+++ b/core/contractHost.chainmail
@@ -33,7 +33,7 @@ interface ContractHost {
    * Seat.
    */
   getInviteIssuer() -> (Issuer);
-};
+}
 
 /**
   * An installation of a Contract can spawn multiple copies each with the same
@@ -67,7 +67,7 @@ interface Installation {
   * they're attempting to participate in, and which seat they are taking.
   */
   checkAmount(installation :Installation, inviteAmount :Amount, terms :Terms);
-};
+}
 
 /**
   * Contracts are pass-by-text.


### PR DESCRIPTION
The IDL doesn't allow structs to declare that they extend another. I'll have to see if it makes sense to add that. For now, we'll comment out the declarations.