### PR TITLE
Allow for custom seats in escrow.js

### DIFF
--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -65,6 +65,7 @@ No invites left`;
       // more general approach to providing useful helpers.
       sameStructure,
       mustBeSameStructure,
+      insist,
     });
     insist(typeof fn === 'function')`\n
 "${functionSrcString}" must be a string for a function, but produced ${typeof fn}`;
@@ -111,7 +112,7 @@ No invites left`;
       // it enables us to use the installation in descriptions rather than the
       // source code itself. The check... methods must be evaluated on install,
       // since they become properties of the installation.
-      function spawn(termsP) {
+      function spawn(termsP, configSrcs) {
         return E.resolve(allComparable(termsP)).then(terms => {
           const inviteMaker = harden({
             // Used by the contract to make invites for credibly
@@ -143,7 +144,7 @@ No invites left`;
             },
             redeem,
           });
-          return startFn(terms, inviteMaker);
+          return startFn(terms, inviteMaker, evaluate, configSrcs);
         });
       }
 

--- a/core/escrow.js
+++ b/core/escrow.js
@@ -3,16 +3,41 @@
 
 import harden from '@agoric/harden';
 import { mustBeSameStructure } from '../util/sameStructure';
+import { insist } from '../util/insist';
 
-// For clarity, the code below internally speaks of a scenario is which Alice is
-// trading some of her money for some of Bob's stock. However, for generality,
-// the API does not expose names like "alice", "bob", "money", or "stock".
-// Rather, Alice and Bob are left and right respectively. Money represents the
-// rights transferred from left to right, and Stock represents the rights
-// transferred from right to left.
-const escrowExchange = {
-  start: (terms, inviteMaker) => {
-    const { left: moneyNeeded, right: stockNeeded } = terms;
+const escrowExchange = harden({
+  // config is used for two customizations: 1) customization the names
+  // of the left and right seat, and 2) customizing the methods on the
+  // seats. For instance, in the case of an escrowed payment that has
+  // an associated use object, `makeCustomLeftSeatSrc` could be a
+  // stringified function that adds a `getUse` method to the seat to
+  // retrieve the use object for the escrowed payment.
+  start: (
+    terms,
+    inviteMaker,
+    evaluate,
+    config = harden({
+      makeCustomLeftSeatSrc: `coreSeat => coreSeat`,
+      makeCustomRightSeatSrc: `coreSeat => coreSeat`,
+    }),
+  ) => {
+    const { makeCustomLeftSeatSrc, makeCustomRightSeatSrc } = config;
+
+    function evalStrToFn(source) {
+      insist(
+        typeof source === 'string',
+      )`"${source}" must be a string, but was ${typeof source}`;
+      const fn = evaluate(source, { harden, E });
+      insist(
+        typeof fn === 'function',
+      )`"${source}" must be a string for a function, but produced ${typeof fn}`;
+      return fn;
+    }
+
+    const makeCustomLeftSeat = evalStrToFn(makeCustomLeftSeatSrc);
+    const makeCustomRightSeat = evalStrToFn(makeCustomRightSeatSrc);
+
+    const { left: leftOfferAmount, right: rightOfferAmount } = terms;
 
     function makeTransfer(amount, srcPaymentP) {
       const { issuer } = amount.label;
@@ -42,53 +67,60 @@ const escrowExchange = {
 
     // Promise wiring
 
-    const moneyPayment = makePromise();
-    const moneyTransfer = makeTransfer(moneyNeeded, moneyPayment.p);
+    const leftOfferPayment = makePromise();
+    const leftEscrow = makeTransfer(leftOfferAmount, leftOfferPayment.p);
 
-    const stockPayment = makePromise();
-    const stockTransfer = makeTransfer(stockNeeded, stockPayment.p);
+    const rightOfferPayment = makePromise();
+    const rightEscrow = makeTransfer(rightOfferAmount, rightOfferPayment.p);
 
     // TODO Use cancellation tokens instead.
-    const aliceCancel = makePromise();
-    const bobCancel = makePromise();
+    const leftCancel = makePromise();
+    const rightCancel = makePromise();
 
     // Set it all in motion optimistically.
 
     const decisionP = Promise.race([
-      Promise.all([moneyTransfer.phase1(), stockTransfer.phase1()]),
-      aliceCancel.p,
-      bobCancel.p,
+      Promise.all([leftEscrow.phase1(), rightEscrow.phase1()]),
+      leftCancel.p,
+      rightCancel.p,
     ]);
     decisionP.then(
       _ => {
-        moneyTransfer.phase2();
-        stockTransfer.phase2();
+        leftEscrow.phase2();
+        rightEscrow.phase2();
       },
       reason => {
-        moneyTransfer.abort(reason);
-        stockTransfer.abort(reason);
+        leftEscrow.abort(reason);
+        rightEscrow.abort(reason);
       },
     );
 
     // Seats
 
-    const aliceSeat = harden({
-      offer: moneyPayment.res,
-      cancel: aliceCancel.reject,
-      getWinnings: stockTransfer.getWinnings,
-      getRefund: moneyTransfer.getRefund,
+    const coreLeftSeat = harden({
+      offer: leftOfferPayment.res,
+      cancel: leftCancel.reject,
+      getWinnings: rightEscrow.getWinnings,
+      getRefund: leftEscrow.getRefund,
     });
 
-    const bobSeat = harden({
-      offer: stockPayment.res,
-      cancel: bobCancel.reject,
-      getWinnings: moneyTransfer.getWinnings,
-      getRefund: stockTransfer.getRefund,
+    const coreRightSeat = harden({
+      offer: rightOfferPayment.res,
+      cancel: rightCancel.reject,
+      getWinnings: leftEscrow.getWinnings,
+      getRefund: rightEscrow.getRefund,
     });
+
+    const leftSeat = makeCustomLeftSeat(coreLeftSeat, leftEscrow, rightEscrow);
+    const rightSeat = makeCustomRightSeat(
+      coreRightSeat,
+      leftEscrow,
+      rightEscrow,
+    );
 
     return harden({
-      left: inviteMaker.make('left', aliceSeat),
-      right: inviteMaker.make('right', bobSeat),
+      left: inviteMaker.make('left', leftSeat),
+      right: inviteMaker.make('right', rightSeat),
     });
   },
 
@@ -107,9 +139,9 @@ const escrowExchange = {
   // Check the left or right side, and return the other. Useful when this is a
   // trade of goods for an invite, for example.
   checkPartialAmount: (installation, allegedInvite, expectedTerms, seat) => {
-    const allegedSeat = allegedInvite.quantity.terms;
+    const allegedSeats = allegedInvite.quantity.terms;
     mustBeSameStructure(
-      allegedSeat[seat],
+      allegedSeats[seat],
       expectedTerms,
       'Escrow checkPartialAmount seat',
     );
@@ -120,14 +152,14 @@ const escrowExchange = {
       'escrow checkPartialAmount installation',
     );
 
-    return seat === 'left' ? allegedSeat.right : allegedSeat.left;
+    return seat === 'left' ? allegedSeats.right : allegedSeats.left;
   },
-};
+});
 
-const escrowExchangeSrcs = {
+const escrowExchangeSrcs = harden({
   start: `${escrowExchange.start}`,
   checkAmount: `${escrowExchange.checkAmount}`,
   checkPartialAmount: `${escrowExchange.checkPartialAmount}`,
-};
+});
 
 export { escrowExchangeSrcs };


### PR DESCRIPTION
This PR adds customizable seats to `escrow.js`.

Customizable seats became necessary when I was trying to create a toy example of a stock that had an associated use object. The user story was that Bob escrows his stock but is still able to use it while in escrow. However, in our current implementation of use objects, when the escrow contract does a `getExclusive` on the offered stock payment, bob loses his use object. To make up for this, the custom seat that Bob gets from the escrow agent includes a method called `getUse` that allows Bob to get his use object while the payment is in escrow. When the payment is transferred to Alice when the transfer is complete, Bob automatically loses any authority his use object had. This follows the pattern of needing to get a new use object every time the underlying amounts of a payment or purse are transferred, and the revocation of the use object from Bob when Alice gains ownership falls out naturally. The code for this test case is up at https://github.com/Agoric/ERTP/tree/stock-dividend-voting