### PR TITLE
Add 'equals' to assay

### DIFF
--- a/core/assays.chainmail
+++ b/core/assays.chainmail
@@ -70,8 +70,10 @@ interface Assay (Amount (Quantity, Label)) {
   /** Returns true if the leftAmount contains the rightAmount. */
   includes(leftAmount :Amount, rightAmount :Amount) -> (boolean);
 
-  /** Returns true if the leftAmount equals the rightAmount. We assume
-  that if includes is true in both directions, equals is also true */
+  /** 
+   * Returns true if the leftAmount equals the rightAmount. We assume
+   * that if includes is true in both directions, equals is also true 
+   */
   equals(leftAmount :Amount, rightAmount :Amount) -> (boolean);
 
   /**

--- a/core/assays.chainmail
+++ b/core/assays.chainmail
@@ -70,6 +70,10 @@ interface Assay (Amount (Quantity, Label)) {
   /** Returns true if the leftAmount contains the rightAmount. */
   includes(leftAmount :Amount, rightAmount :Amount) -> (boolean);
 
+  /** Returns true if the leftAmount equals the rightAmount. We assume
+  that if includes is true in both directions, equals is also true */
+  equals(leftAmount :Amount, rightAmount :Amount) -> (boolean);
+
   /**
    * Returns a new amount that includes both leftAmount and rightAmount.
    *

--- a/core/config/assays.js
+++ b/core/config/assays.js
@@ -99,6 +99,10 @@ Unrecognized amount: ${amount}`;
       return assay.quantity(leftAmount) >= assay.quantity(rightAmount);
     },
 
+    equals(leftAmount, rightAmount) {
+      return assay.quantity(leftAmount) === assay.quantity(rightAmount);
+    },
+
     // Set union of erights.
     // Describe all the erights described by `leftAmount` and those
     // described by `rightAmount`.
@@ -194,6 +198,13 @@ Unrecognized amount: ${amount}`;
           return true;
         }
         return sameStructure(leftQuant, rightQuant);
+      },
+
+      equals(leftAmount, rightAmount) {
+        return (
+          assay.includes(leftAmount, rightAmount) &&
+          assay.includes(rightAmount, leftAmount)
+        );
       },
 
       with(leftAmount, rightAmount) {

--- a/more/pixels/pixelAssays.js
+++ b/more/pixels/pixelAssays.js
@@ -86,6 +86,13 @@ function makePixelListAssayMaker(canvasSize) {
         return includesPixelList(leftPixelList, rightPixelList);
       },
 
+      equals(leftAmount, rightAmount) {
+        return (
+          assay.includes(leftAmount, rightAmount) &&
+          assay.includes(rightAmount, leftAmount)
+        );
+      },
+
       // set union
       with(leftAmount, rightAmount) {
         const leftPixelList = assay.quantity(leftAmount);


### PR DESCRIPTION
Closes #74 

In implementing #63, it became apparent that it would be helpful to be able to compare two amounts to see if they are equal. Specifically, we often use a pattern where an amount equal to the full balance is passed into `deposit`, `burn`, and `getExclusive` in order to check that our understanding of the balance is correct. Chris suggested changing `deposit`, `burn`, and `getExclusive` to `depositExactly`, `burnExactly`, and `getExclusiveExactly` to be able to still use this pattern even with payment linearity. 

The implementations of `depositExactly`, `burnExactly`, and `getExclusiveExactly` could use `equals` to easily compare the passed-in amount to the balance of the payment to fail-fast if the amount doesn't equal the balance. 

We can use `includes` in both directions as a hack, but in many cases, the assay, with knowledge of what it is working with, could provide a more efficient `equals` function.