### PR TITLE
WIP: Pegs preserve original label

### DIFF
--- a/core/issuers.js
+++ b/core/issuers.js
@@ -125,7 +125,7 @@ Description must be truthy: ${description}`;
   let label = harden({ issuer, description });
   const assay = makeAssay(label);
   label = assay.getLabel();
-  
+
   const mintKeeper = makeMintKeeper(assay);
   const { purseKeeper, paymentKeeper } = mintKeeper;
 

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -120,9 +120,12 @@ Description must be truthy: ${description}`;
   // additional methods
   const issuer = makeCustomIssuer(coreIssuer);
 
-  const label = harden({ issuer, description });
-
+  // This module only suggests a label to makeAssay. But the actual
+  // label is what makeAssay says it is.
+  let label = harden({ issuer, description });
   const assay = makeAssay(label);
+  label = assay.getLabel();
+  
   const mintKeeper = makeMintKeeper(assay);
   const { purseKeeper, paymentKeeper } = mintKeeper;
 

--- a/more/peg/peg.js
+++ b/more/peg/peg.js
@@ -1,71 +1,71 @@
 import harden from '@agoric/harden';
-import { makeNatAssay } from '../../core/config/assays';
-import { makeMint } from '../../core/issuers';
 
-// This implementation may be out of date
+import { makeMint } from '../../core/issuers';
+import { makeBasicFungibleConfig } from '../../core/config/basicFungibleConfig';
+import { makeRemoteLabelConfigMaker } from './remoteLabelConfig';
 
 // Creates a local issuer that locally represents a remotely issued
 // currency. Returns a promise for a peg object that asynchonously
 // converts between the two. The local currency is synchronously
 // transferable locally.
-function makePeg(E, remoteIssuerP, makeMintKeeper, makeAssay = makeNatAssay) {
+//
+// The `E` argument will go away once `E` becomes pure and safely
+// importable.
+//
+// The `makeOverriddenConfig` should be an adequate local analog of
+// the `makeConfig` that was used to make the remote issuer. However,
+// the peg abstraction below overrides it to make assays and amounts
+// with the remote issuer's label.
+function makePeg(
+  E,
+  remoteIssuerP,
+  makeOverriddenConfig = makeBasicFungibleConfig,
+) {
   const remoteLabelP = E(remoteIssuerP).getLabel();
+  const backingPursePP = E(remoteIssuerP).makeEmptyPurse('backing');
 
-  // The remoteLabel is a local copy of the remote pass-by-copy
-  // label. It has a presence of the remote issuer and a copy of the
-  // description.
-  return Promise.resolve(remoteLabelP).then(remoteLabel => {
-    // Retaining remote currency deposits it in here.
-    // Redeeming local currency withdraws remote from here.
-    const backingPurseP = E(remoteIssuerP).makeEmptyPurse('backing');
+  return Promise.all([remoteLabelP, backingPursePP]).then(
+    // The remoteLabel is a local copy of the remote pass-by-copy
+    // label. It has a presence of the remote issuer and a copy of the
+    // description.
+    //
+    // Retaining a remote payment deposits it in backingPurseP.
+    // Redeeming a local payment withdraws the remote payment from
+    // backingPurseP.
+    ([remoteLabel, backingPurseP]) => {
+      const { description } = remoteLabel;
+      const makeRemoteLabelConfig = makeRemoteLabelConfigMaker(
+        makeOverriddenConfig,
+        remoteLabel,
+      );
+      const localMint = makeMint(description, makeRemoteLabelConfig);
+      const localIssuer = localMint.getIssuer();
 
-    const { description } = remoteLabel;
-    const localMint = makeMint(description, makeMintKeeper, makeAssay);
-    const localIssuer = localMint.getIssuer();
-    const localLabel = localIssuer.getLabel();
-
-    function localAmountOf(remoteAmount) {
       return harden({
-        label: localLabel,
-        quantity: remoteAmount.quantity,
+        getLocalIssuer() {
+          return localIssuer;
+        },
+
+        getRemoteIssuer() {
+          return remoteIssuerP;
+        },
+
+        retainAll(remotePaymentP, name = 'backed') {
+          return E(backingPurseP)
+            .depositAll(remotePaymentP)
+            .then(amount =>
+              localMint.mint(amount, `${name} purse`).withdrawAll(name),
+            );
+        },
+
+        redeemAll(localPayment, name = 'redeemed') {
+          return localIssuer
+            .burnAll(localPayment)
+            .then(amount => E(backingPurseP).withdraw(amount, name));
+        },
       });
-    }
-
-    function remoteAmountOf(localAmount) {
-      return harden({
-        label: remoteLabel,
-        quantity: localAmount.quantity,
-      });
-    }
-
-    return harden({
-      getLocalIssuer() {
-        return localIssuer;
-      },
-
-      getRemoteIssuer() {
-        return remoteIssuerP;
-      },
-
-      retainAll(remotePaymentP, name = 'backed') {
-        return E(backingPurseP)
-          .depositAll(remotePaymentP)
-          .then(remoteAmount =>
-            localMint
-              .mint(localAmountOf(remoteAmount), `${name} purse`)
-              .withdrawAll(name),
-          );
-      },
-
-      redeemAll(localPayment, name = 'redeemed') {
-        return localIssuer
-          .burnAll(localPayment)
-          .then(localAmount =>
-            E(backingPurseP).withdraw(remoteAmountOf(localAmount), name),
-          );
-      },
-    });
-  });
+    },
+  );
 }
 harden(makePeg);
 

--- a/more/peg/remoteLabelConfig.js
+++ b/more/peg/remoteLabelConfig.js
@@ -1,0 +1,22 @@
+import harden from '@agoric/harden';
+
+// Returns a makeConfig function like `superMakeConfig`, except that
+// its makeAssay function will ignore the label passed to it, and
+// instead use `remoteLabel` for the assays it makes. Those assays
+// will therefore label the amounts it makes with `remoteLabel`
+// instead of the label that was passed to makeAssay.
+function makeRemoteLabelConfigMaker(superMakeConfig, remoteLabel) {
+  function makeRemoteLabelConfig() {
+    const { makeAssay: superMakeAssay, ...restConfig } = superMakeConfig();
+    function makeAssayWithRemoteLabel(_ignoredLabel) {
+      return superMakeAssay(remoteLabel);
+    }
+    return harden({
+      ...restConfig,
+      makeAssay: makeAssayWithRemoteLabel,
+    });
+  }
+  return harden(makeRemoteLabelConfig);
+}
+
+export { makeRemoteLabelConfigMaker };


### PR DESCRIPTION
WIP: Not yet a candidate, as it has not yet been run or tested. However, I'm posting this now as 
   * This updates `makePeg` to be compatible with our new `makeConfig`-based system for making mints and issuers.
   * Scooter is about to depend on this change in behavior.

The peg's new local assay uses the label of the remote issuer, so the amounts it makes are labeled as from that issuer. They are not endorsed by that issuer, but they wouldn't be anyway since they are distant and pass-by-copy. Rather, they coerce to amounts accepted by the remote issuer.

This has pros and cons. 
   * The pros help use of a local peg merely as a bookkeeping advice to track updates to a remotely held escrow purse, as is done in scooter. 
   * The cons are that abstractions, like the escrow exchange that are parameterized by amounts, rather than (issuer,amount) pairs, will extract the intended issuer from the amount, routing around the peg's issuer. Sometimes this will even be intended. When not intended, we'll need to pass (issuer,amount) pairs instead. 