### PR TITLE
gallery.js: setColor now subsumes changeColor, changeColorAll

### DIFF
--- a/GALLERY-README.md
+++ b/GALLERY-README.md
@@ -83,7 +83,7 @@ with coloring the pixels in the underlying purse or payment) that can
 be called. To color, the user does:
 
 ```js
-E(useObj).changeColorAll('#000000');
+E(useObj).setColor('#000000');
 ```
 
 with the hex color of their choice. 

--- a/more/pixels/gallery.js
+++ b/more/pixels/gallery.js
@@ -101,9 +101,11 @@ export function makeGallery(
 
   function makeUseObj(issuer, asset) {
     const useObj = harden({
-      // change the color of the pixels in the amount after checking
+      // change the color of the pixels in optAmount after checking
       // that the asset has the authority to do so.
-      changeColor(amount, newColor) {
+      // if optAmount is falsey, use the entire balance of the asset
+      setColor(newColor, optAmount) {
+        const amount = optAmount || asset.getBalance();
         // TODO: allow empty amounts to be used without throwing
         // an error, but because there is no authority, nothing happens.
         insistNonEmptyAmount(issuer, amount);
@@ -113,10 +115,13 @@ export function makeGallery(
         setPixelListState(pixelList, newColor);
         return amount;
       },
-      // Call changeColor, just with the entire balance of the
-      // underlying asset.
+      // Deprecated wrapper for setColor.
+      changeColor(amount, newColor) {
+        return useObj.setColor(newColor, amount);
+      },
+      // Deprecated wrapper for setColor.
       changeColorAll(newColor) {
-        return useObj.changeColor(asset.getBalance(), newColor);
+        return useObj.setColor(newColor);
       },
       // A helper function for getting a literal list of pixels from
       // the asset. For example, [ { x:0, y:0 } ]

--- a/test/swingsetTests/gallery/bootstrap.js
+++ b/test/swingsetTests/gallery/bootstrap.js
@@ -13,7 +13,7 @@ function build(E, log) {
   async function testAliceChangesColor(aliceMaker, gallery) {
     log('starting testAliceChangesColor');
     const aliceP = E(aliceMaker).make(gallery.userFacet);
-    const alicePixelAmount = await E(aliceP).doChangeColor();
+    const alicePixelAmount = await E(aliceP).doSetColor();
     const rawPixel = alicePixelAmount.quantity[0];
     log(
       `current color ${gallery.userFacet.getPixelColor(

--- a/test/swingsetTests/gallery/test-gallery.js
+++ b/test/swingsetTests/gallery/test-gallery.js
@@ -41,7 +41,7 @@ const expectedAliceChangesColorLog = [
   'starting aliceChangesColor',
   'alice is made',
   'starting testAliceChangesColor',
-  '++ alice.doChangeColor starting',
+  '++ alice.doSetColor starting',
   'tapped Faucet',
   'current color #000000',
   'pixel index is 100 of 100',

--- a/test/swingsetTests/gallery/vat-alice.js
+++ b/test/swingsetTests/gallery/vat-alice.js
@@ -59,11 +59,11 @@ function makeAliceMaker(E, log, contractHost) {
           const pixelPaymentP = E(gallery).tapFaucet();
           showPaymentBalance('pixel from faucet', pixelPaymentP);
         },
-        async doChangeColor() {
-          log('++ alice.doChangeColor starting');
+        async doSetColor() {
+          log('++ alice.doSetColor starting');
           const pixelPaymentP = E(gallery).tapFaucet();
           const pixels = E(pixelPaymentP).getUse();
-          const changedAmount = await E(pixels).changeColorAll('#000000');
+          const changedAmount = await E(pixels).setColor('#000000');
           log('tapped Faucet');
           return changedAmount;
         },
@@ -108,7 +108,7 @@ function makeAliceMaker(E, log, contractHost) {
 
           // alice takes the right back
           await E(pixelPaymentP).revokeChildren();
-          await E(pixels).changeColorAll(
+          await E(pixels).setColor(
             '#9FBF95', // a light green
           );
 
@@ -156,10 +156,10 @@ function makeAliceMaker(E, log, contractHost) {
         },
         async checkAfterRevoked() {
           log('++ alice.checkAfterRevoked starting');
-          // changeColor throws an Error with an empty payment
+          // setColor throws an Error with an empty payment
           // check transferRight is empty
           E(storedUseObj)
-            .changeColorAll(
+            .setColor(
               '#9FBF95', // a light green
             )
             .then(
@@ -248,11 +248,11 @@ function makeAliceMaker(E, log, contractHost) {
           // create a fake childMint controlled entirely by Alice
           function makeUseObj(issuer, asset) {
             const useObj = harden({
-              changeColor(amount, _newColor) {
+              setColor(_newColor, amount) {
+                if (!amount) {
+                  return asset.getBalance();
+                }
                 return amount;
-              },
-              changeColorAll(newColor) {
-                return useObj.changeColor(asset.getBalance(), newColor);
               },
               getRawPixels() {
                 const assay = issuer.getAssay();

--- a/test/swingsetTests/gallery/vat-bob.js
+++ b/test/swingsetTests/gallery/vat-bob.js
@@ -29,7 +29,7 @@ function makeBobMaker(E, log) {
           const useObj = await E(newPayment).getUse();
 
           // bob actually changes the color to light purple
-          const amountP = await E(useObj).changeColorAll('#B695C0');
+          const amountP = await E(useObj).setColor('#B695C0');
 
           storedERTPAsset = newPayment;
           storedPixels = useObj;
@@ -37,13 +37,13 @@ function makeBobMaker(E, log) {
         },
         async tryToColorPixels() {
           // bob tries to change the color to light purple
-          const amountP = await E(storedPixels).changeColorAll('#B695C0');
+          const amountP = await E(storedPixels).setColor('#B695C0');
           return amountP;
         },
         async tryToColorERTP() {
           // bob tries to change the color to light purple
           const pixels = await E(storedERTPAsset).getUse();
-          const amountP = await E(pixels).changeColorAll('#B695C0');
+          const amountP = await E(pixels).setColor('#B695C0');
           return amountP;
         },
         async buyFromCorkBoard(handoffSvc, dustPurseP) {
@@ -66,7 +66,7 @@ function makeBobMaker(E, log) {
 
           // bob tries to change the color to light purple
           E(useObj)
-            .changeColorAll('#B695C0')
+            .setColor('#B695C0')
             .then(
               amountP => {
                 E(gallery)

--- a/test/unitTests/more/pixels/test-gallery.js
+++ b/test/unitTests/more/pixels/test-gallery.js
@@ -39,7 +39,7 @@ test('the user changes the color of a pixel', async t => {
   const pixels = payment.getUse();
   const rawPixels = pixels.getRawPixels();
   const rawPixel = rawPixels[0];
-  pixels.changeColorAll('#000000');
+  pixels.setColor('#000000');
   t.equal(userFacet.getPixelColor(rawPixel.x, rawPixel.y), '#000000');
   t.end();
 });


### PR DESCRIPTION
The first argument to setColor is a color.  The second argument
is an optional amount, which defaults to all pixels in the asset.

```js
home.gallery!tapFaucet()!getUse()!setColor('green')
```

This makes the demo a little more usable.  Next time we do a breaking
change of ERTP, we may want to remove the old changeColor* methods.
