### PR TITLE
Make the `makeMint` config more trait-like

### DIFF
--- a/core/config/noCustomization.js
+++ b/core/config/noCustomization.js
@@ -7,17 +7,17 @@ import harden from '@agoric/harden';
 // These methods must be paired with a mintKeeper and Assay to be a
 // full configuration that can be passed into `makeMint`.
 const noCustomization = harden({
-  makeCustomPayment(superPayment) {
-    return superPayment;
+  makePaymentTrait(_superPayment) {
+    return harden({});
   },
-  makeCustomPurse(superPurse) {
-    return superPurse;
+  makePurseTrait(_superPurse) {
+    return harden({});
   },
-  makeCustomMint(superMint) {
-    return superMint;
+  makeMintTrait(_superMint) {
+    return harden({});
   },
-  makeCustomIssuer(superIssuer) {
-    return superIssuer;
+  makeIssuerTrait(_superIssuer) {
+    return harden({});
   },
 });
 

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -24,10 +24,10 @@ Description must be truthy: ${description}`;
   // Each of these methods is used below and must be defined (even in
   // a trivial way) in any configuration
   const {
-    makeCustomIssuer,
-    makeCustomPayment,
-    makeCustomPurse,
-    makeCustomMint,
+    makeIssuerTrait,
+    makePaymentTrait,
+    makePurseTrait,
+    makeMintTrait,
     makeMintKeeper,
     makeAssay,
   } = makeConfig();
@@ -52,10 +52,12 @@ Description must be truthy: ${description}`;
       },
     });
 
-    // makeCustomPayment is defined in the passed-in configuration and
-    // allows for the customization of the payment, including adding
-    // additional methods
-    const payment = makeCustomPayment(corePayment, issuer);
+    // makePaymentTrait is defined in the passed-in configuration and adds
+    // additional methods to corePayment
+    const payment = harden({
+      ...makePaymentTrait(corePayment, issuer),
+      ...corePayment,
+    });
 
     // ///////////////// commit point //////////////////
     // All queries above passed with no side effects.
@@ -115,10 +117,12 @@ Description must be truthy: ${description}`;
     },
   });
 
-  // makeCustomIssuer is defined in the passed-in configuration and
-  // allows for the customization of the issuer, including adding
-  // additional methods
-  const issuer = makeCustomIssuer(coreIssuer);
+  // makeIssuerTrait is defined in the passed-in configuration and adds
+  // additional methods to coreIssuer.
+  const issuer = harden({
+    ...makeIssuerTrait(coreIssuer),
+    ...coreIssuer,
+  });
 
   const label = harden({ issuer, description });
 
@@ -189,19 +193,24 @@ Description must be truthy: ${description}`;
         },
       });
 
-      // makeCustomPurse is defined in the passed-in configuration and
-      // allows for the customization of the purse, including adding
-      // additional methods
-      const purse = makeCustomPurse(corePurse, issuer);
+      // makePurseTrait is defined in the passed-in configuration and
+      // adds additional methods to corePurse
+      const purse = harden({
+        ...makePurseTrait(corePurse, issuer),
+        ...corePurse,
+      });
+
       purseKeeper.recordNew(purse, initialBalance);
       return purse;
     },
   });
 
-  // makeCustomMint is defined in the passed-in configuration and
-  // allows for the customization of the mint, including adding
-  // additional methods
-  const mint = makeCustomMint(coreMint, issuer, assay, mintKeeper);
+  // makeMintTrait is defined in the passed-in configuration and
+  // adds additional methods to coreMint
+  const mint = harden({
+    ...makeMintTrait(coreMint, issuer, assay, mintKeeper),
+    ...coreMint,
+  });
 
   return mint;
 }

--- a/more/pixels/pixelConfig.js
+++ b/more/pixels/pixelConfig.js
@@ -61,9 +61,8 @@ function makePixelConfigMaker(
     }
 
     return harden({
-      makeCustomPayment(superPayment, issuer) {
+      makePaymentTrait(superPayment, issuer) {
         return harden({
-          ...superPayment,
           // This creates a new use object on every call. Please see
           // the gallery for the definition of the use object that is
           // created here by calling `makeUseObj`
@@ -88,9 +87,8 @@ function makePixelConfigMaker(
           },
         });
       },
-      makeCustomPurse(superPurse, issuer) {
+      makePurseTrait(superPurse, issuer) {
         return harden({
-          ...superPurse,
           // This creates a new use object on every call. Please see
           // the gallery for the definition of the use object that is
           // created here by calling `makeUseObj`
@@ -111,9 +109,8 @@ function makePixelConfigMaker(
           },
         });
       },
-      makeCustomMint(superMint, issuer, assay, mintKeeper) {
+      makeMintTrait(_superMint, issuer, assay, mintKeeper) {
         return harden({
-          ...superMint,
           // revoke destroys the amount from this mint and calls
           // revoke on the childMint with an amount of the same
           // quantity. Destroying the amount depends on the fact that
@@ -131,9 +128,8 @@ function makePixelConfigMaker(
           },
         });
       },
-      makeCustomIssuer(superIssuer) {
+      makeIssuerTrait(superIssuer) {
         return harden({
-          ...superIssuer,
           // The parent issuer is one level up in the chain of
           // issuers.
           getParentIssuer() {


### PR DESCRIPTION
Closes #79 

This PR changes the `makeMint` config to be more trait-like. Instead of the config being able to create an entirely custom payment/purse/etc, the config functions are only able to add additional methods to payments/purses/etc. We are able to enforce this securely by moving back to an "object merge" pattern in which a new object is created by using the spread operator (...) on both the "core" and "custom" method objects. We ensure that the object with the "core" methods is the second spread expression in the object merge, thus overwriting any custom methods in the same name space as the core methods. 