### PR TITLE
Import manager

### DIFF
--- a/more/imports/importManager.js
+++ b/more/imports/importManager.js
@@ -13,34 +13,26 @@ import harden from '@agoric/harden';
 // would import or define some functions, then call
 //
 //   const mgr = importManager();
-//   mgr.addImport('usefulFn', export1);
-//   mgr.addImport('helpfulFn', export2);
-//   return mgr.lock();
+//   return mgr.addExports(
+//     {
+//        'usefulFn', export1,
+//        'helpfulFn', export2,
+//      });
 //
 // then it could pass strings like 'usefulFn' to clients, who could import the
 // manager above, then call
 //
 // const genericFn = importer.lookupImport(name);
+//
 function importManager() {
-  const entries = new Map();
+  const entries = {};
 
   return harden({
-    addImport(name, referent) {
-      if (entries.has(name)) {
-        throw new Error(`Name "${name}" already has an entry.`);
+    addExports(obj) {
+      for (const name of Object.getOwnPropertyNames(obj)) {
+        entries[name] = obj[name];
       }
-      entries.set(name, referent);
-    },
-
-    lock() {
-      return harden({
-        lookupImport(name) {
-          if (!entries.has(name)) {
-            throw new Error(`There is no entry for "${name}".`);
-          }
-          return entries.get(name);
-        },
-      });
+      return harden(entries);
     },
   });
 }

--- a/more/imports/importManager.js
+++ b/more/imports/importManager.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+
+// ImportManager allows a package to make some code available that can be run
+// locally by a calling vat without requiring a remote round trip to the hosting
+// vat. Remote code can indicate what function to run using a key.
+//
+// Long term, we may want to import from a well-known repository, and manage
+// version upgrades, but for now, we just import the code from the file system.
+//
+// A package that wanted to export some code for clients to run in their own vat
+// would import or define some functions, then call
+//
+//   const mgr = importManager();
+//   mgr.addImport('usefulFn', export1);
+//   mgr.addImport('helpfulFn', export2);
+//   return mgr.lock();
+//
+// then it could pass strings like 'usefulFn' to clients, who could import the
+// manager above, then call
+//
+// const genericFn = importer.lookupImport(name);
+function importManager() {
+  const entries = new Map();
+
+  return harden({
+    addImport(name, referent) {
+      if (entries.has(name)) {
+        throw new Error(`Name "${name}" already has an entry.`);
+      }
+      entries.set(name, referent);
+    },
+
+    lock() {
+      return harden({
+        lookupImport(name) {
+          if (!entries.has(name)) {
+            throw new Error(`There is no entry for "${name}".`);
+          }
+          return entries.get(name);
+        },
+      });
+    },
+  });
+}
+
+export { importManager };

--- a/test/unitTests/more/imports/badImports.js
+++ b/test/unitTests/more/imports/badImports.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import { importManager } from '../../../../more/imports/importManager';
+
+function makeBadImportManager() {
+  function double(x) {
+    return x * 2;
+  }
+  const mgr = importManager();
+  mgr.addImport('a', 37);
+  mgr.addImport('a', double);
+  return mgr.lock();
+}
+
+export { makeBadImportManager };

--- a/test/unitTests/more/imports/badImports.js
+++ b/test/unitTests/more/imports/badImports.js
@@ -1,15 +1,14 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import { importManager } from '../../../../more/imports/importManager';
+import { listIsEmpty, numIsEmpty } from './strategy';
 
 function makeBadImportManager() {
-  function double(x) {
-    return x * 2;
-  }
   const mgr = importManager();
-  mgr.addImport('a', 37);
-  mgr.addImport('a', double);
-  return mgr.lock();
+  const obj = { numIsEmpty };
+  const fooSym = Symbol('foo');
+  obj[fooSym] = listIsEmpty;
+  return mgr.addExports(obj);
 }
 
 export { makeBadImportManager };

--- a/test/unitTests/more/imports/goodImports.js
+++ b/test/unitTests/more/imports/goodImports.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import { importManager } from '../../../../more/imports/importManager';
+
+function makeGoodImportManager() {
+  function double(x) {
+    return x * 2;
+  }
+  const mgr = importManager();
+  mgr.addImport('a', 37);
+  mgr.addImport('b', double);
+  return mgr.lock();
+}
+
+export { makeGoodImportManager };

--- a/test/unitTests/more/imports/goodImports.js
+++ b/test/unitTests/more/imports/goodImports.js
@@ -1,15 +1,13 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
+import { numIsEmpty, listIsEmpty } from './strategy';
 import { importManager } from '../../../../more/imports/importManager';
 
+// This file models the way a module could export functionality to be run
+// locally within a vat, but with the behavior determined by remote objects.
 function makeGoodImportManager() {
-  function double(x) {
-    return x * 2;
-  }
   const mgr = importManager();
-  mgr.addImport('a', 37);
-  mgr.addImport('b', double);
-  return mgr.lock();
+  return mgr.addExports({ numIsEmpty, listIsEmpty });
 }
 
 export { makeGoodImportManager };

--- a/test/unitTests/more/imports/strategy.js
+++ b/test/unitTests/more/imports/strategy.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+// These represent two functions that could be provided by different sources,
+// but which we want to call polymorphically using the import manager.
+function numIsEmpty(quantity) {
+  return quantity === 0;
+}
+
+function listIsEmpty(list) {
+  return list.length === 0;
+}
+
+export { numIsEmpty, listIsEmpty };

--- a/test/unitTests/more/imports/test-importsA.js
+++ b/test/unitTests/more/imports/test-importsA.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import { test } from 'tape-promise/tape';
+import { makeGoodImportManager } from './goodImports';
+import { makeBadImportManager } from './badImports';
+
+test('import integer', t => {
+  const importer = makeGoodImportManager();
+  t.equals(37, importer.lookupImport('a'));
+  t.end();
+});
+
+test('import function', t => {
+  const importer = makeGoodImportManager();
+  t.equals(40, importer.lookupImport('b')(20));
+  t.end();
+});
+
+test('import not found', t => {
+  const importer = makeGoodImportManager();
+  t.throws(() => importer.lookupImport('c'), 'There is no entry for "c".');
+  t.end();
+});
+
+test('duplicate import', t => {
+  t.throws(() => makeBadImportManager(), '"a" already has an entry.');
+  t.end();
+});

--- a/test/unitTests/more/imports/test-importsA.js
+++ b/test/unitTests/more/imports/test-importsA.js
@@ -2,27 +2,42 @@
 
 import { test } from 'tape-promise/tape';
 import { makeGoodImportManager } from './goodImports';
-import { makeBadImportManager } from './badImports';
 
-test('import integer', t => {
+test('import num is not empty', t => {
   const importer = makeGoodImportManager();
-  t.equals(37, importer.lookupImport('a'));
+  const name = 'numIsEmpty';
+  const emptyFn = importer[name];
+  t.notOk(emptyFn(30));
   t.end();
 });
 
-test('import function', t => {
+test('import num is empty', t => {
   const importer = makeGoodImportManager();
-  t.equals(40, importer.lookupImport('b')(20));
+  const name = 'numIsEmpty';
+  const emptyFn = importer[name];
+  t.assert(emptyFn(0));
+  t.end();
+});
+
+test('import listIsEmpty (false)', t => {
+  const importer = makeGoodImportManager();
+  const op = 'listIsEmpty';
+  t.notok(importer[op]([20]));
+  t.end();
+});
+
+test('import listIsEmpty (true)', t => {
+  const importer = makeGoodImportManager();
+  const op = 'listIsEmpty';
+  t.assert(importer[op]([]));
   t.end();
 });
 
 test('import not found', t => {
   const importer = makeGoodImportManager();
-  t.throws(() => importer.lookupImport('c'), 'There is no entry for "c".');
-  t.end();
-});
-
-test('duplicate import', t => {
-  t.throws(() => makeBadImportManager(), '"a" already has an entry.');
+  t.throws(
+    () => importer.lookupImport('emptyPixel'),
+    'There is no entry for "c".',
+  );
   t.end();
 });


### PR DESCRIPTION
As described in https://github.com/Agoric/ERTP/issues/102, it would be useful to allow modules to provide code for their clients to run locally without requiring round trips to the hosting objects. Zoe/Scooter might benefit from being able to execute code provided by strategies without needing to call methods in separate vats. Similarly, some of the verification code provided by contracts in the contract host could be run locally by a client.

This is an interim solution that works by directly importing the code into the client, but allowing the remote objects to dispatch to different polymorphic functions by returning a string to use as a selector.