### PR TITLE
Add Seat Mint

### DIFF
--- a/core/config/configs.md
+++ b/core/config/configs.md
@@ -1,0 +1,152 @@
+## Custom Mints and Other Configurations
+
+The `makeMint` function in `issuers.js` takes in a configuration
+function that can change a number of things about how mints, issuers,
+purses, and payments are made. 
+
+By default, `makeBasicFungibleConfig` is used. This creates a mint for
+a fungible token with no custom methods.
+
+But, imagine that we want to add a custom method to the `mint` object.
+Maybe we want to be able to know how much has been minted so far. To
+do so, we will need to create our own custom configuration. 
+
+Our custom configuration will look like this:
+
+```js
+const makeTotalSupplyConfig = () => {
+
+  function* makePaymentTrait(_superPayment) {
+    yield harden({});
+  }
+
+  function* makePurseTrait(_superPurse) {
+    yield harden({});
+  }
+
+  function* makeMintTrait(_superMint, _issuer, _assay, mintKeeper) {
+    return yield harden({
+      getTotalSupply: () => mintKeeper.getTotalSupply(),
+    });
+  }
+
+  function* makeIssuerTrait(_superIssuer) {
+    yield harden({});
+  }
+
+  return harden({
+    makePaymentTrait,
+    makePurseTrait,
+    makeMintTrait,
+    makeIssuerTrait,
+    makeMintKeeper: makeTotalSupplyMintKeeper,
+    strategy: natStrategy,
+    makeMintTrait,
+  });
+};
+```
+
+In this custom configuration, we've done two things: we've added a
+method to `mint` called `getTotalSupply`, and we've changed the
+`mintKeeper` to a custom mintKeeper that keeps track of the total
+supply for us (more on this in separate documentation). 
+
+Let's take a look into how we are able to add new methods to mints,
+issuers, purses, and payments. 
+
+In `makePaymentTrait`, we take `superPayment` as a parameter. The
+`superPayment` is constructed in `issuers.js` and has all of the
+methods we are familiar with:
+
+```js
+const superPayment = harden({
+  getIssuer() {
+    return issuer;
+  },
+  getBalance() {
+    return paymentKeeper.getAmount(payment);
+  },
+  getName() {
+    return name;
+  },
+});
+```
+
+Our custom code, `makePaymentTrait`, returns an object with custom methods.
+These methods will be added to the `superPayment`. For this particular
+customization, we want to leave payments alone, so we will create a
+generator function that yields an empty object:
+
+```js
+function* makePaymentTrait(_superPayment) {
+  yield harden({});
+}
+```
+
+However, we do want to add an extra method to mints. So,
+`makeMintTrait` is defined as:
+
+```js
+function* makeMintTrait(_superMint, _issuer, _assay, mintKeeper) {
+  return yield harden({
+    getTotalSupply: () => mintKeeper.getTotalSupply(),
+  });
+}
+```
+
+Back in `issuers.js`, our custom methods will be combined with the
+"core" methods already present. Here's how that works for our custom
+mint methods:
+
+```js
+const makeMintTraitIter = makeMintTrait(coreMint, issuer, assay, mintKeeper);
+const mintTrait = makeMintTraitIter.next().value;
+const mint = harden({
+  ...mintTrait,
+  ...coreMint,
+});
+makeMintTraitIter.next(mint);
+```
+
+## The Trait Pattern
+
+As a general rule, we do not want the customization code to be able to
+override the methods already on the mints, issuers, purses or
+payments. It would hardly be a standard if the standard methods acted
+entirely differently! On the other hand, we do know that there is a
+genuine need to have slightly different purposes expressed. 
+
+This is why we've chosen to use the [Trait
+pattern](https://traitsjs.github.io/traits.js-website/), in which
+custom behavior can be defined and recombined easily. (Note: We don't
+currently use the Trait.js infrastructure, but the philosophy is the
+same.) Furthermore, if we always combine the methods such that the
+"core" methods are last, they cannot be overridden by the custom
+methods. 
+
+So we're good, right? Well, almost.
+
+## Why generator functions?
+
+Sometimes, we want to burn the payment in the custom method. That
+caused a problem, because without generators, we don't actually have
+access to the payment! We only have access to the `superPayment` that
+is passed in as a parameter. When we call `issuer.burnAll(payment)`,
+the payment gets looked up in a WeakMap of all the payments and their
+current balances. However, the superPayment won't be in that WeakMap.
+The finished payment (the superPayment plus the custom methods) is
+what is in the WeakMap. So we must have access to *that* payment. 
+
+There's a contradiction there. We wanted to ensure that the custom
+code couldn't override or mess with the core methods, but now we're
+saying that we should hand off the whole, un-`hardened` payment to the
+custom code. 
+
+There's a way to get around this contradiction: generator functions.
+We can still use the trait pattern. However, we can also give access
+to the `hardened`, final version of the payment that is the core + custom methods.
+
+Here's how that happens:
+
+* temporal dead zone
+* ??

--- a/core/config/configs.md
+++ b/core/config/configs.md
@@ -127,12 +127,13 @@ So we're good, right? Well, almost.
 
 Sometimes, we want to burn the payment in the custom method. That
 caused a problem because with normal functions we don't actually have
-access to the payment! We only have access to the `corePayment` that
+access to the full payment, the one which is built by adding methods to the
+`corePayment`. We only have access to the `corePayment` that
 is passed in as a parameter. When we call `issuer.burnAll(payment)`,
 the payment gets looked up in a WeakMap of all the payments and their
 current balances. However, the corePayment won't be in that WeakMap.
-The finished payment (the corePayment plus the custom methods) is
-what is in the WeakMap. So we must have access to *that* payment. 
+The finished payment (the corePayment plus the custom methods) is what
+is in the WeakMap. So we must have access to *that* payment. 
 
 There's a contradiction there. We wanted to ensure that the custom
 code couldn't override or mess with the core methods, but now we're

--- a/core/config/configs.md
+++ b/core/config/configs.md
@@ -16,21 +16,21 @@ Our custom configuration will look like this:
 ```js
 const makeTotalSupplyConfig = () => {
 
-  function* makePaymentTrait(_superPayment) {
+  function* makePaymentTrait(_corePayment) {
     yield harden({});
   }
 
-  function* makePurseTrait(_superPurse) {
+  function* makePurseTrait(_corePurse) {
     yield harden({});
   }
 
-  function* makeMintTrait(_superMint, _issuer, _assay, mintKeeper) {
+  function* makeMintTrait(_coreMint, _issuer, _assay, mintKeeper) {
     return yield harden({
       getTotalSupply: () => mintKeeper.getTotalSupply(),
     });
   }
 
-  function* makeIssuerTrait(_superIssuer) {
+  function* makeIssuerTrait(_coreIssuer) {
     yield harden({});
   }
 
@@ -54,12 +54,12 @@ supply for us (more on this in separate documentation).
 Let's take a look into how we are able to add new methods to mints,
 issuers, purses, and payments. 
 
-In `makePaymentTrait`, we take `superPayment` as a parameter. The
-`superPayment` is constructed in `issuers.js` and has all of the
+In `makePaymentTrait`, we take `corePayment` as a parameter. The
+`corePayment` is constructed in `issuers.js` and has all of the
 methods we are familiar with:
 
 ```js
-const superPayment = harden({
+const corePayment = harden({
   getIssuer() {
     return issuer;
   },
@@ -73,12 +73,12 @@ const superPayment = harden({
 ```
 
 Our custom code, `makePaymentTrait`, returns an object with custom methods.
-These methods will be added to the `superPayment`. For this particular
+These methods will be added to the `corePayment`. For this particular
 customization, we want to leave payments alone, so we will create a
 generator function that yields an empty object:
 
 ```js
-function* makePaymentTrait(_superPayment) {
+function* makePaymentTrait(_corePayment) {
   yield harden({});
 }
 ```
@@ -87,7 +87,7 @@ However, we do want to add an extra method to mints. So,
 `makeMintTrait` is defined as:
 
 ```js
-function* makeMintTrait(_superMint, _issuer, _assay, mintKeeper) {
+function* makeMintTrait(_coreMint, _issuer, _assay, mintKeeper) {
   return yield harden({
     getTotalSupply: () => mintKeeper.getTotalSupply(),
   });
@@ -110,31 +110,28 @@ makeMintTraitIter.next(mint);
 
 ## The Trait Pattern
 
-As a general rule, we do not want the customization code to be able to
-override the methods already on the mints, issuers, purses or
-payments. It would hardly be a standard if the standard methods acted
-entirely differently! On the other hand, we do know that there is a
-genuine need to have slightly different purposes expressed. 
+We want the core behavior of mints, issuers, purses and payments to be
+consistent and reliable across different types of assets. On the other
+hand, we do know that there is a genuine need to have slightly
+different purposes expressed.
 
 This is why we've chosen to use the [Trait
-pattern](https://traitsjs.github.io/traits.js-website/), in which
-custom behavior can be defined and recombined easily. (Note: We don't
-currently use the Trait.js infrastructure, but the philosophy is the
-same.) Furthermore, if we always combine the methods such that the
-"core" methods are last, they cannot be overridden by the custom
-methods. 
+pattern](https://en.wikipedia.org/wiki/Trait_(computer_programming)),
+in which custom behavior can be defined and recombined easily.
+Furthermore, if we always combine the methods such that the "core"
+methods are last, they cannot be overridden by the custom methods. 
 
 So we're good, right? Well, almost.
 
 ## Why generator functions?
 
 Sometimes, we want to burn the payment in the custom method. That
-caused a problem, because without generators, we don't actually have
-access to the payment! We only have access to the `superPayment` that
+caused a problem because with normal functions we don't actually have
+access to the payment! We only have access to the `corePayment` that
 is passed in as a parameter. When we call `issuer.burnAll(payment)`,
 the payment gets looked up in a WeakMap of all the payments and their
-current balances. However, the superPayment won't be in that WeakMap.
-The finished payment (the superPayment plus the custom methods) is
+current balances. However, the corePayment won't be in that WeakMap.
+The finished payment (the corePayment plus the custom methods) is
 what is in the WeakMap. So we must have access to *that* payment. 
 
 There's a contradiction there. We wanted to ensure that the custom

--- a/core/config/noCustomization.js
+++ b/core/config/noCustomization.js
@@ -6,19 +6,28 @@ import harden from '@agoric/harden';
 
 // These methods must be paired with a mintKeeper and Assay to be a
 // full configuration that can be passed into `makeMint`.
+
+function* makePaymentTrait(_superPayment) {
+  yield harden({});
+}
+
+function* makePurseTrait(_superPurse) {
+  yield harden({});
+}
+
+function* makeMintTrait(_superMint) {
+  yield harden({});
+}
+
+function* makeIssuerTrait(_superIssuer) {
+  yield harden({});
+}
+
 const noCustomization = harden({
-  makePaymentTrait(_superPayment) {
-    return harden({});
-  },
-  makePurseTrait(_superPurse) {
-    return harden({});
-  },
-  makeMintTrait(_superMint) {
-    return harden({});
-  },
-  makeIssuerTrait(_superIssuer) {
-    return harden({});
-  },
+  makePaymentTrait,
+  makePurseTrait,
+  makeMintTrait,
+  makeIssuerTrait,
 });
 
 export { noCustomization };

--- a/core/config/noCustomization.js
+++ b/core/config/noCustomization.js
@@ -7,19 +7,19 @@ import harden from '@agoric/harden';
 // These methods must be paired with a mintKeeper and Assay to be a
 // full configuration that can be passed into `makeMint`.
 
-function* makePaymentTrait(_superPayment) {
+function* makePaymentTrait(_corePayment) {
   yield harden({});
 }
 
-function* makePurseTrait(_superPurse) {
+function* makePurseTrait(_corePurse) {
   yield harden({});
 }
 
-function* makeMintTrait(_superMint) {
+function* makeMintTrait(_coreMint) {
   yield harden({});
 }
 
-function* makeIssuerTrait(_superIssuer) {
+function* makeIssuerTrait(_coreIssuer) {
   yield harden({});
 }
 

--- a/core/config/seatConfig.js
+++ b/core/config/seatConfig.js
@@ -17,7 +17,7 @@ import { seatStrategy } from './strategies/seatStrategy';
  */
 function makeSeatConfigMaker(makeUseObjForPayment, makeUseObjForPurse) {
   function makeSeatConfig() {
-    function* makePaymentTrait(_superPayment, issuer) {
+    function* makePaymentTrait(_corePayment, issuer) {
       const payment = yield harden({
         // This creates a new use object which destroys the payment
         unwrap: () => makeUseObjForPayment(issuer, payment),
@@ -25,7 +25,7 @@ function makeSeatConfigMaker(makeUseObjForPayment, makeUseObjForPurse) {
       return payment;
     }
 
-    function* makePurseTrait(_superPurse, issuer) {
+    function* makePurseTrait(_corePurse, issuer) {
       const purse = yield harden({
         // This creates a new use object which empties the purse
         unwrap: () => makeUseObjForPurse(issuer, purse),
@@ -33,11 +33,11 @@ function makeSeatConfigMaker(makeUseObjForPayment, makeUseObjForPurse) {
       return purse;
     }
 
-    function* makeMintTrait(_superMint) {
+    function* makeMintTrait(_coreMint) {
       return yield harden({});
     }
 
-    function* makeIssuerTrait(_superIssuer) {
+    function* makeIssuerTrait(_coreIssuer) {
       return yield harden({});
     }
 

--- a/core/config/seatConfig.js
+++ b/core/config/seatConfig.js
@@ -1,0 +1,56 @@
+import harden from '@agoric/harden';
+
+import { makeCoreMintKeeper } from './coreMintKeeper';
+import { seatStrategy } from './strategies/seatStrategy';
+
+/**
+ * `makeSeatConfigMaker` exists in order to pass in two makeUseObj
+ * functions, one for payments and one for purses. A "use object" has
+ * all of the non-ERTP methods for assets that are designed to be
+ * used. For instance, a stock might have vote() and
+ * claimCashDividends() as methods. The use object is associated with
+ * an underlying asset that provides the authority to use it.
+ * @param {function} makeUseObjForPayment creates a "use object" for
+ * payments
+ * @param {function} makeUseObjForPurse creates a "use object" for
+ * purses
+ */
+function makeSeatConfigMaker(makeUseObjForPayment, makeUseObjForPurse) {
+  function makeSeatConfig() {
+    function* makePaymentTrait(_superPayment, issuer) {
+      const payment = yield harden({
+        // This creates a new use object which destroys the payment
+        unwrap: () => makeUseObjForPayment(issuer, payment),
+      });
+      return payment;
+    }
+
+    function* makePurseTrait(_superPurse, issuer) {
+      const purse = yield harden({
+        // This creates a new use object which empties the purse
+        unwrap: () => makeUseObjForPurse(issuer, purse),
+      });
+      return purse;
+    }
+
+    function* makeMintTrait(_superMint) {
+      return yield harden({});
+    }
+
+    function* makeIssuerTrait(_superIssuer) {
+      return yield harden({});
+    }
+
+    return harden({
+      makePaymentTrait,
+      makePurseTrait,
+      makeMintTrait,
+      makeIssuerTrait,
+      makeMintKeeper: makeCoreMintKeeper,
+      strategy: seatStrategy,
+    });
+  }
+  return makeSeatConfig;
+}
+
+export { makeSeatConfigMaker };

--- a/core/config/strategies/seatStrategy.js
+++ b/core/config/strategies/seatStrategy.js
@@ -1,0 +1,48 @@
+import harden from '@agoric/harden';
+import { passStyleOf } from '@agoric/marshal';
+
+import { insist } from '../../../util/insist';
+import { makeUniStrategy } from './uniStrategy';
+
+/*
+ * A seat quantity may look like:
+ *
+ * {
+ *   id: {},
+ *   offerToBeMade: [rule1, rule2],
+ * }
+ *
+ * or:
+ *
+ * {
+ *   id: {},
+ *   offerMade: [rule1, rule2],
+ * }
+ *
+ */
+
+const insistSeat = seat => {
+  const properties = Object.getOwnPropertyNames(seat);
+  insist(
+    properties.length === 2,
+  )`must have the properties 'id', and 'offerToBeMade' or 'offerMade'`;
+  insist(properties.includes('id'))`must include 'id'`;
+  insist(
+    properties.includes('offerToBeMade') || properties.includes('offerMade'),
+  )`must include 'offerToBeMade' or 'offerMade'`;
+  insist(
+    passStyleOf(seat.id) === 'presence' &&
+      Object.entries(seat.id).length === 0 &&
+      seat.id.constructor === Object,
+  )`id should be an empty object`;
+  insist(
+    passStyleOf(seat.offerToBeMade) === 'copyArray' ||
+      passStyleOf(seat.offerMade) === 'copyArray',
+  )`an offer should be an array`;
+  return seat;
+};
+
+const seatStrategy = makeUniStrategy(insistSeat);
+harden(seatStrategy);
+
+export { seatStrategy };

--- a/core/config/strategies/uniStrategy.js
+++ b/core/config/strategies/uniStrategy.js
@@ -7,64 +7,58 @@ import {
   mustBeComparable,
 } from '../../../util/sameStructure';
 
-// A uniAssay makes uni amounts, which are either empty or have unique
-// descriptions. The quantity must either be null, in which case it is
-// empty, or be some truthy comparable value, in which case it
-// represents a single unique unit described by that truthy
-// quantity. Combining two uni amounts with different truthy
-// quantities fails, as they represent non-combinable rights.
-const makeUniStrategy = (descriptionCoercer = d => d) => {
+// The uniStrategy represents quantities that can never be combined.
+// For example, usually there is only one invite in an invite purse or
+// payment. (Using a listStrategy is an alternative, but when there is
+// usually a quantity of one, it's bothersome to always have to grab
+// the first item in the list rather than just represent the item
+// itself.)
+
+// The uni quantities are either empty (null) or unique. Combining two
+// non-null uni quantities fails because they represent non-combinable
+// rights. In a commonly used pattern, uni quantities contain an id
+// represented by a unique empty object.
+
+// `customInsistKind` enforces the particular kind of thing represented. For
+// example, the quantity in an invitation to join a contract might look like:
+// {
+//   id: harden({}),
+//   offerToBeMade: [rule1, rule2],
+// }
+
+const makeUniStrategy = customInsistKind => {
   const uniStrategy = harden({
-    insistKind: optDescription => {
-      if (optDescription === null) {
+    insistKind: quantity => {
+      if (quantity === null) {
         return null;
       }
-      insist(
-        !!optDescription,
-      )`Uni optDescription must be either null or truthy: ${optDescription}`;
-      mustBeComparable(optDescription);
-      const description = descriptionCoercer(optDescription);
-      insist(!!description)`Uni description must be truthy ${description}`;
-      mustBeComparable(description);
-      return description;
+      mustBeComparable(quantity);
+      return customInsistKind(quantity);
     },
     empty: _ => null,
     isEmpty: uni => uni === null,
     includes: (whole, part) => {
-      if (part === null) {
-        return true;
-      }
-      return sameStructure(whole, part);
+      // the part is only included in the whole if the part is null or
+      // if the part equals the whole
+      return uniStrategy.isEmpty(part) || uniStrategy.equals(whole, part);
     },
-    equals: (left, right) =>
-      uniStrategy.includes(left, right) && uniStrategy.includes(right, left),
+    equals: sameStructure,
     with: (left, right) => {
-      if (left === null) {
+      // left and right can only be added together if one of them is null
+      if (uniStrategy.isEmpty(left)) {
         return right;
       }
-      if (right === null) {
+      if (uniStrategy.isEmpty(right)) {
         return left;
       }
-      if (sameStructure(left, right)) {
-        // The "throw" is useless since insist(false) will unconditionally
-        // throw anyway. Rather, it informs IDEs of this control flow.
-        throw insist(
-          false,
-        )`Even identical non-empty uni amounts cannot be added together ${left}`;
-      } else {
-        // The "throw" is useless since insist(false) will unconditionally
-        // throw anyway. Rather, it informs IDEs of this control flow.
-        throw insist(
-          false,
-        )`Cannot combine different uni descriptions ${left} vs ${right}`;
-      }
+      throw insist(false)`Cannot combine uni quantities ${left} and ${right}`;
     },
     without: (whole, part) => {
-      if (part === null) {
+      // we can only subtract the part from the whole if either part
+      // is null or the part equals the whole
+      if (uniStrategy.isEmpty(part)) {
         return whole;
       }
-      insist(whole !== null)`Empty left does not include ${part}`;
-
       mustBeSameStructure(
         whole,
         part,

--- a/core/config/uniAssayConfig.js
+++ b/core/config/uniAssayConfig.js
@@ -4,15 +4,29 @@ import { noCustomization } from './noCustomization';
 import { makeCoreMintKeeper } from './coreMintKeeper';
 import { makeUniStrategy } from './strategies/uniStrategy';
 
+import { insist } from '../../util/insist';
+import { mustBeComparable } from '../../util/sameStructure';
+
 // This UniAssay config is used to create invites and similar assets.
 // It does not customize the purses, payments, mints, or issuers, and
 // it uses the core mintKeeper as well as the uniAssay (naturally)
-function makeUniAssayConfigMaker(descriptionCoercer) {
+const makeCustomInsistKind = descriptionCoercer => optDescription => {
+  insist(
+    !!optDescription,
+  )`Uni optDescription must be either null or truthy: ${optDescription}`;
+  const description = descriptionCoercer(optDescription);
+  insist(!!description)`Uni description must be truthy ${description}`;
+  mustBeComparable(description);
+  return description;
+};
+
+function makeUniAssayConfigMaker(descriptionCoercer = () => true) {
+  const customInsistKind = makeCustomInsistKind(descriptionCoercer);
   function makeUniAssayConfig() {
     return harden({
       ...noCustomization,
       makeMintKeeper: makeCoreMintKeeper,
-      strategy: makeUniStrategy(descriptionCoercer),
+      strategy: makeUniStrategy(customInsistKind),
     });
   }
   return makeUniAssayConfig;

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -67,10 +67,13 @@ Description must be truthy: ${description}`;
 
     // makePaymentTrait is defined in the passed-in configuration and adds
     // additional methods to corePayment
+    const makePaymentTraitIter = makePaymentTrait(corePayment, issuer);
+    const paymentTrait = makePaymentTraitIter.next().value;
     const payment = harden({
-      ...makePaymentTrait(corePayment, issuer),
+      ...paymentTrait,
       ...corePayment,
     });
+    makePaymentTraitIter.next(payment);
 
     // ///////////////// commit point //////////////////
     // All queries above passed with no side effects.
@@ -100,10 +103,13 @@ Description must be truthy: ${description}`;
     });
     // makePaymentTrait is defined in the passed-in configuration and adds
     // additional methods to corePayment
+    const makePaymentTraitIter = makePaymentTrait(corePayment, issuer);
+    const paymentTrait = makePaymentTraitIter.next().value;
     const payment = harden({
-      ...makePaymentTrait(corePayment, issuer),
+      ...paymentTrait,
       ...corePayment,
     });
+    makePaymentTraitIter.next(payment);
 
     // ///////////////// commit point //////////////////
     // All queries above passed with no side effects.
@@ -225,10 +231,13 @@ Description must be truthy: ${description}`;
 
   // makeIssuerTrait is defined in the passed-in configuration and adds
   // additional methods to coreIssuer.
+  const makeIssuerTraitIter = makeIssuerTrait(coreIssuer);
+  const issuerTrait = makeIssuerTraitIter.next().value;
   const issuer = harden({
-    ...makeIssuerTrait(coreIssuer),
+    ...issuerTrait,
     ...coreIssuer,
   });
+  makeIssuerTraitIter.next(issuer);
 
   const label = harden({ issuer, description });
 
@@ -297,10 +306,13 @@ Description must be truthy: ${description}`;
 
       // makePurseTrait is defined in the passed-in configuration and
       // adds additional methods to corePurse
+      const makePurseTraitIter = makePurseTrait(corePurse, issuer);
+      const purseTrait = makePurseTraitIter.next().value;
       const purse = harden({
-        ...makePurseTrait(corePurse, issuer),
+        ...purseTrait,
         ...corePurse,
       });
+      makePurseTraitIter.next(purse);
 
       purseKeeper.recordNew(purse, initialBalance);
       return purse;
@@ -309,10 +321,13 @@ Description must be truthy: ${description}`;
 
   // makeMintTrait is defined in the passed-in configuration and
   // adds additional methods to coreMint
+  const makeMintTraitIter = makeMintTrait(coreMint, issuer, assay, mintKeeper);
+  const mintTrait = makeMintTraitIter.next().value;
   const mint = harden({
-    ...makeMintTrait(coreMint, issuer, assay, mintKeeper),
+    ...mintTrait,
     ...coreMint,
   });
+  makeMintTraitIter.next(mint);
 
   return mint;
 }

--- a/core/seatMint.js
+++ b/core/seatMint.js
@@ -1,0 +1,62 @@
+import harden from '@agoric/harden';
+
+import { makeSeatConfigMaker } from './config/seatConfig';
+import { makeMint } from './issuers';
+
+/**
+ * `makeSeatMint` creates an instance of the seatMint with an
+ * associated WeakMap mapping ids (represented by unique empty
+ * objects) to use objects
+ */
+const makeSeatMint = (description = 'seats') => {
+  const idObjsToSeats = new WeakMap();
+
+  const addUseObj = (idObj, useObj) => {
+    idObjsToSeats.set(idObj, useObj);
+  };
+
+  const makeUseObj = seatQuantity => {
+    return harden(idObjsToSeats.get(seatQuantity.id));
+  };
+
+  const paymentMakeUseAndBurn = async (issuer, payment) => {
+    const { quantity } = payment.getBalance();
+    if (quantity === null) {
+      throw new Error('the payment is empty or already used');
+    }
+    const useObj = makeUseObj(quantity);
+    await issuer.burnAll(payment);
+    return useObj;
+  };
+
+  // Note that we can't burn the underlying purse, we can only empty
+  // it and burn the payment we withdraw.
+  const purseMakeUseAndBurn = async (issuer, purse) => {
+    const { quantity } = purse.getBalance();
+    if (quantity === null) {
+      throw new Error('the purse is empty or already used');
+    }
+    const useObj = makeUseObj(quantity);
+    const payment = purse.withdrawAll();
+    await issuer.burnAll(payment);
+    return useObj;
+  };
+
+  const makeSeatConfig = makeSeatConfigMaker(
+    paymentMakeUseAndBurn,
+    purseMakeUseAndBurn,
+  );
+
+  const seatMint = makeMint(description, makeSeatConfig);
+  const seatIssuer = seatMint.getIssuer();
+
+  return harden({
+    seatMint,
+    seatIssuer,
+    addUseObj,
+  });
+};
+
+harden(makeSeatMint);
+
+export { makeSeatMint };

--- a/more/pixels/pixelConfig.js
+++ b/more/pixels/pixelConfig.js
@@ -58,99 +58,100 @@ function makePixelConfigMaker(
       return childIssuer.makeAmount(quantity);
     }
 
-    return harden({
-      makePaymentTrait(superPayment, issuer) {
-        return harden({
-          // This creates a new use object on every call. Please see
-          // the gallery for the definition of the use object that is
-          // created here by calling `makeUseObj`
-          getUse() {
-            return makeUseObj(issuer, superPayment);
-          },
-          // Revoke all descendants of this payment and mint a new
-          // payment from the child mint with the same quantity as the
-          // original payment
-          claimChild() {
-            prepareChildMint(issuer);
-            const childAmount = getChildAmount(
-              issuer,
-              superPayment.getBalance(),
-            );
-            // Remove the amount of this payment from the purses and
-            // payments of the childMint. Removes recursively down the
-            // chain until it fails to find a childMint.
-            childMint.revoke(childAmount);
-            const childPurse = childMint.mint(childAmount);
-            return childPurse.withdrawAll();
-          },
-        });
-      },
-      makePurseTrait(superPurse, issuer) {
-        return harden({
-          // This creates a new use object on every call. Please see
-          // the gallery for the definition of the use object that is
-          // created here by calling `makeUseObj`
-          getUse() {
-            return makeUseObj(issuer, superPurse);
-          },
-          // Revoke all descendants of this purse and mint a new purse
-          // from the child mint with the same quantity as the
-          // original purse
-          claimChild() {
-            prepareChildMint(issuer);
-            const childAmount = getChildAmount(issuer, superPurse.getBalance());
-            // Remove the amount of this payment from the purses and
-            // payments of the childMint. Removes recursively down the
-            // chain until it fails to find a childMint.
-            childMint.revoke(childAmount);
-            return childMint.mint(childAmount);
-          },
-        });
-      },
-      makeMintTrait(_superMint, issuer, assay, mintKeeper) {
-        return harden({
-          // revoke destroys the amount from this mint and calls
-          // revoke on the childMint with an amount of the same
-          // quantity. Destroying the amount depends on the fact that
-          // pixels are uniquely identifiable by their `x` and `y`
-          // coordinates. Therefore, destroy can look for purses and
-          // payments that include those particular pixels and remove
-          // the particular pixels from those purses or payments
-          revoke(amount) {
-            amount = assay.coerce(amount);
+    function* makePaymentTrait(superPayment, issuer) {
+      yield harden({
+        // This creates a new use object on every call. Please see
+        // the gallery for the definition of the use object that is
+        // created here by calling `makeUseObj`
+        getUse() {
+          return makeUseObj(issuer, superPayment);
+        },
+        // Revoke all descendants of this payment and mint a new
+        // payment from the child mint with the same quantity as the
+        // original payment
+        claimChild() {
+          prepareChildMint(issuer);
+          const childAmount = getChildAmount(issuer, superPayment.getBalance());
+          // Remove the amount of this payment from the purses and
+          // payments of the childMint. Removes recursively down the
+          // chain until it fails to find a childMint.
+          childMint.revoke(childAmount);
+          const childPurse = childMint.mint(childAmount);
+          return childPurse.withdrawAll();
+        },
+      });
+    }
+    function* makePurseTrait(superPurse, issuer) {
+      yield harden({
+        // This creates a new use object on every call. Please see
+        // the gallery for the definition of the use object that is
+        // created here by calling `makeUseObj`
+        getUse() {
+          return makeUseObj(issuer, superPurse);
+        },
+        // Revoke all descendants of this purse and mint a new purse
+        // from the child mint with the same quantity as the
+        // original purse
+        claimChild() {
+          prepareChildMint(issuer);
+          const childAmount = getChildAmount(issuer, superPurse.getBalance());
+          // Remove the amount of this payment from the purses and
+          // payments of the childMint. Removes recursively down the
+          // chain until it fails to find a childMint.
+          childMint.revoke(childAmount);
+          return childMint.mint(childAmount);
+        },
+      });
+    }
+    function* makeMintTrait(_superMint, issuer, assay, mintKeeper) {
+      yield harden({
+        // revoke destroys the amount from this mint and calls
+        // revoke on the childMint with an amount of the same
+        // quantity. Destroying the amount depends on the fact that
+        // pixels are uniquely identifiable by their `x` and `y`
+        // coordinates. Therefore, destroy can look for purses and
+        // payments that include those particular pixels and remove
+        // the particular pixels from those purses or payments
+        revoke(amount) {
+          amount = assay.coerce(amount);
 
-            mintKeeper.destroy(amount);
-            if (childMint !== undefined) {
-              childMint.revoke(getChildAmount(issuer, amount)); // recursively revoke child assets
-            }
-          },
-        });
-      },
-      makeIssuerTrait(superIssuer) {
-        return harden({
-          // The parent issuer is one level up in the chain of
-          // issuers.
-          getParentIssuer() {
-            return parentIssuer;
-          },
-          // The child issuer is one level down in the chain of issuers.
-          getChildIssuer() {
-            prepareChildMint(superIssuer);
-            return childIssuer;
-          },
-          // Returns true if the alleged descendant issuer is either a
-          // child, grandchild, or any other kind of descendant
-          isDescendantIssuer(allegedDescendant) {
-            if (childIssuer === undefined) {
-              return false;
-            }
-            if (childIssuer === allegedDescendant) {
-              return true;
-            }
-            return childIssuer.isDescendantIssuer(allegedDescendant);
-          },
-        });
-      },
+          mintKeeper.destroy(amount);
+          if (childMint !== undefined) {
+            childMint.revoke(getChildAmount(issuer, amount)); // recursively revoke child assets
+          }
+        },
+      });
+    }
+    function* makeIssuerTrait(superIssuer) {
+      yield harden({
+        // The parent issuer is one level up in the chain of
+        // issuers.
+        getParentIssuer() {
+          return parentIssuer;
+        },
+        // The child issuer is one level down in the chain of issuers.
+        getChildIssuer() {
+          prepareChildMint(superIssuer);
+          return childIssuer;
+        },
+        // Returns true if the alleged descendant issuer is either a
+        // child, grandchild, or any other kind of descendant
+        isDescendantIssuer(allegedDescendant) {
+          if (childIssuer === undefined) {
+            return false;
+          }
+          if (childIssuer === allegedDescendant) {
+            return true;
+          }
+          return childIssuer.isDescendantIssuer(allegedDescendant);
+        },
+      });
+    }
+    return harden({
+      makePaymentTrait,
+      makePurseTrait,
+      makeMintTrait,
+      makeIssuerTrait,
       makeMintKeeper: makePixelMintKeeper,
       strategy: makePixelStrategy(canvasSize),
     });

--- a/more/pixels/pixelConfig.js
+++ b/more/pixels/pixelConfig.js
@@ -58,20 +58,20 @@ function makePixelConfigMaker(
       return childIssuer.makeAmount(quantity);
     }
 
-    function* makePaymentTrait(superPayment, issuer) {
+    function* makePaymentTrait(corePayment, issuer) {
       yield harden({
         // This creates a new use object on every call. Please see
         // the gallery for the definition of the use object that is
         // created here by calling `makeUseObj`
         getUse() {
-          return makeUseObj(issuer, superPayment);
+          return makeUseObj(issuer, corePayment);
         },
         // Revoke all descendants of this payment and mint a new
         // payment from the child mint with the same quantity as the
         // original payment
         claimChild() {
           prepareChildMint(issuer);
-          const childAmount = getChildAmount(issuer, superPayment.getBalance());
+          const childAmount = getChildAmount(issuer, corePayment.getBalance());
           // Remove the amount of this payment from the purses and
           // payments of the childMint. Removes recursively down the
           // chain until it fails to find a childMint.
@@ -81,20 +81,20 @@ function makePixelConfigMaker(
         },
       });
     }
-    function* makePurseTrait(superPurse, issuer) {
+    function* makePurseTrait(corePurse, issuer) {
       yield harden({
         // This creates a new use object on every call. Please see
         // the gallery for the definition of the use object that is
         // created here by calling `makeUseObj`
         getUse() {
-          return makeUseObj(issuer, superPurse);
+          return makeUseObj(issuer, corePurse);
         },
         // Revoke all descendants of this purse and mint a new purse
         // from the child mint with the same quantity as the
         // original purse
         claimChild() {
           prepareChildMint(issuer);
-          const childAmount = getChildAmount(issuer, superPurse.getBalance());
+          const childAmount = getChildAmount(issuer, corePurse.getBalance());
           // Remove the amount of this payment from the purses and
           // payments of the childMint. Removes recursively down the
           // chain until it fails to find a childMint.
@@ -103,7 +103,7 @@ function makePixelConfigMaker(
         },
       });
     }
-    function* makeMintTrait(_superMint, issuer, assay, mintKeeper) {
+    function* makeMintTrait(_coreMint, issuer, assay, mintKeeper) {
       yield harden({
         // revoke destroys the amount from this mint and calls
         // revoke on the childMint with an amount of the same
@@ -122,7 +122,7 @@ function makePixelConfigMaker(
         },
       });
     }
-    function* makeIssuerTrait(superIssuer) {
+    function* makeIssuerTrait(coreIssuer) {
       yield harden({
         // The parent issuer is one level up in the chain of
         // issuers.
@@ -131,7 +131,7 @@ function makePixelConfigMaker(
         },
         // The child issuer is one level down in the chain of issuers.
         getChildIssuer() {
-          prepareChildMint(superIssuer);
+          prepareChildMint(coreIssuer);
           return childIssuer;
         },
         // Returns true if the alleged descendant issuer is either a

--- a/test/unitTests/core/test-seat.js
+++ b/test/unitTests/core/test-seat.js
@@ -1,0 +1,135 @@
+import { test } from 'tape-promise/tape';
+import harden from '@agoric/harden';
+
+import { makeSeatMint } from '../../../core/seatMint';
+import { makeMint } from '../../../core/issuers';
+import { insist } from '../../../util/insist';
+
+/*
+ * A seat quantity may look like:
+ *
+ * {
+ *   id: {},
+ *   offerToBeMade: [rule1, rule2],
+ * }
+ *
+ * or:
+ *
+ * {
+ *   id: {},
+ *   offerMade: [rule1, rule2],
+ * }
+ *
+ */
+
+const bothTrue = (prev, curr) => prev && curr;
+
+const ruleEqual = (leftRule, rightRule) => leftRule.rule === rightRule.rule;
+
+const amountEqual = (assay, leftRule, rightRule) =>
+  assay.equals(leftRule.amount, rightRule.amount);
+
+const offerEqual = (assays, leftOffer, rightOffer) => {
+  const isLengthEqual = leftOffer.length === rightOffer.length;
+  if (!isLengthEqual) {
+    return false;
+  }
+  return leftOffer
+    .map((leftRule, i) => {
+      return (
+        ruleEqual(leftRule, rightOffer[i]) &&
+        amountEqual(assays[i], leftRule, rightOffer[i])
+      );
+    })
+    .reduce(bothTrue);
+};
+
+const setup = () => {
+  const moolaMint = makeMint('moola');
+  const simoleanMint = makeMint('simoleans');
+  const bucksMint = makeMint('bucks');
+
+  const moolaIssuer = moolaMint.getIssuer();
+  const simoleanIssuer = simoleanMint.getIssuer();
+  const bucksIssuer = bucksMint.getIssuer();
+
+  const moolaAssay = moolaIssuer.getAssay();
+  const simoleanAssay = simoleanIssuer.getAssay();
+  const bucksAssay = bucksIssuer.getAssay();
+
+  return harden({
+    mints: [moolaMint, simoleanMint, bucksMint],
+    issuers: [moolaIssuer, simoleanIssuer, bucksIssuer],
+    assays: [moolaAssay, simoleanAssay, bucksAssay],
+  });
+};
+
+test('seatMint', async t => {
+  const { assays } = setup();
+  const { seatMint, addUseObj } = makeSeatMint();
+
+  const makeUseObj = quantity => {
+    insist(quantity !== null)`the asset is empty or already used`;
+    if (quantity.offerToBeMade) {
+      return harden({
+        makeOffer: offer => {
+          insist(offerEqual(assays, offer, quantity.offerToBeMade));
+          // do things with the offer
+          return true;
+        },
+      });
+    }
+    if (quantity.offerMade) {
+      return harden({
+        claim: () => {
+          return [];
+        },
+      });
+    }
+    return harden({});
+  };
+
+  const purse1Quantity = harden({
+    id: harden({}),
+    offerToBeMade: [
+      { rule: 'haveExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+    ],
+  });
+
+  const purse1 = seatMint.mint(purse1Quantity);
+  t.deepEqual(purse1.getBalance().quantity, purse1Quantity);
+  addUseObj(purse1Quantity.id, makeUseObj(purse1Quantity));
+
+  const useObjPurse1 = await purse1.unwrap();
+  // purse1 should be empty at this point. Note that `withdrawAll` doesn't
+  // destroy purses; it just empties the balance.
+  t.deepEqual(purse1.getBalance().quantity, null);
+
+  t.rejects(purse1.unwrap(), /the purse is empty or already used/);
+
+  t.equal(useObjPurse1.makeOffer(purse1Quantity.offerToBeMade), true);
+
+  const purse2Quantity = harden({
+    id: harden({}),
+    offerMade: [
+      { rule: 'haveExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+    ],
+  });
+
+  const purse2 = seatMint.mint(purse2Quantity);
+  t.deepEqual(purse2.getBalance().quantity, purse2Quantity);
+  addUseObj(purse2Quantity.id, makeUseObj(purse2Quantity));
+
+  const useObjPurse2 = await purse2.unwrap();
+  // purse1 should be empty at this point. Note that `withdrawAll` doesn't
+  // destroy purses; it just empties the balance.
+  t.deepEqual(purse2.getBalance().quantity, null);
+
+  t.rejects(purse2.unwrap(), /the purse is empty or already used/);
+
+  t.deepEqual(useObjPurse2.claim(), []);
+
+  t.end();
+});


### PR DESCRIPTION
This PR is part of the current Zoe implementation. (I've [split Zoe up for better review](https://github.com/Agoric/ERTP/issues/134).) It gives users the ability to easily create ERTP payments for "seats" (we need to sort out the various names for ERTP, but let's do that in one big meeting rather than in this PR.) for their contracts.  A seat can either represent the right to make an offer (an "invite") or the right to claim the outcome of making an offer (a "position"). Seats are ERTP payments which have a use object that can be obtained by calling `unwrap`. `Unwrap` burns the underlying payment (or in the case of a purse, withdraws the full balance and burns that, leaving the underlying purse empty). The interface of the use object is entirely flexible and up to the developer. 

Two modifications were necessary:
1. Updating the "trait-like" customization of `issuers.js` with an approach invented by @erights  that gives the custom code access to the full payment, purse, mint, issuer while still not allowing the custom code the ability to override the core ERTP methods. This turned out to be necessary to be able to burn the payments within the custom code. When the custom code only had access to the core/super payment, purse, etc., the attempt to burn would fail because of course, the core payment, purse, etc. were different objects than the final version (after customization) that was actually stored in the weakmap.
2. Making UniStrategy more generalizable to be able to reuse it. I also cleaned up the language a bit - please let me know if I've left anything out.

