### PR TITLE
Add "areRightsConserved" and "isOfferSafe" functions with tests

### DIFF
--- a/core/zoe/areRightsConserved.js
+++ b/core/zoe/areRightsConserved.js
@@ -1,0 +1,47 @@
+import { bothTrue, transpose } from './utils';
+
+/**
+ * The columns in a `quantities` matrix are per issuer, and the rows
+ * are per player. We want to transpose the matrix such that each
+ * row is per issuer so we can do 'with' on the array to get a total
+ * per issuer and make sure the rights are conserved.
+ * @param  {strategy[]} strategies - an array of strategies per issuer
+ * @param  {quantity[]} quantities - an array of arrays with a row per
+ * player indexed by issuer
+ */
+const sumByIssuer = (strategies, quantities) =>
+  transpose(quantities).map((quantitiesPerIssuer, i) => {
+    return quantitiesPerIssuer.reduce(strategies[i].with);
+  });
+
+/**
+ * Does the left array of summed quantities equal the right array of
+ * summed quantities?
+ * @param  {strategy[]} strategies - an array of strategies per issuer
+ * @param  {quantity[]} leftQuantities - an array of total quantities per issuer
+ * @param  {quantity[]} rightQuantities - an array of total quantities per issuer
+ * indexed by issuer
+ */
+const isEqualPerIssuer = (strategies, leftQuantities, rightQuantities) =>
+  leftQuantities
+    .map((leftQ, i) => strategies[i].equals(leftQ, rightQuantities[i]))
+    .reduce(bothTrue, true);
+
+/**
+ * `areRightsConserved` checks that the total quantity per issuer stays
+ * the same regardless of the reallocation.
+ * @param  {strategy[]} strategies - an array of strategies per issuer
+ * @param  {quantity[][]} previousQuantities - array of arrays where a row
+ * is the array of quantities for a particular player, per
+ * issuer
+ * @param  {quantity[][]} newQuantities - array of arrays where a row
+ * is the array of reallocated quantities for a particular player, per
+ * issuer
+ */
+function areRightsConserved(strategies, prevQuantities, newQuantities) {
+  const sumsPrevQuantities = sumByIssuer(strategies, prevQuantities);
+  const sumsNewQuantities = sumByIssuer(strategies, newQuantities);
+  return isEqualPerIssuer(strategies, sumsPrevQuantities, sumsNewQuantities);
+}
+
+export { areRightsConserved };

--- a/core/zoe/isOfferSafe.js
+++ b/core/zoe/isOfferSafe.js
@@ -1,0 +1,119 @@
+import { bothTrue } from './utils';
+import { insist } from '../../util/insist';
+
+/**
+ * `isOfferSafeForPlayer` checks offer-safety for a single player.
+ *
+ * Note: This implementation checks whether we refund for all rules or
+ * return winnings for all rules. It does not allow some refunds and
+ * some winnings, which is what would happen if you checked the rules
+ * independently. It *does* allow for returning a full refund plus
+ * full winnings.
+ *
+ * @param  {strategy[]} strategies - an array of strategies ordered in
+ * the same order as the corresponding issuers
+ * @param  {offerDescElem[]} offerDesc - the offer description, an
+ * array of objects that have a rule and amount, in the same order as
+ * the corresponding issuers. The offer description is a player's
+ * understanding of the contract that they are entering when they make
+ * an offer. OfferDescElements are structured in the form `{ rule:
+ * descriptionString, amount}`
+ * @param  {quantity[]} quantities - an array of quantities ordered in
+ * the same order as the corresponding issuers. This array of quantities
+ * is the reallocation to be given to a player.
+ */
+function isOfferSafeForPlayer(strategies, offerDesc, quantities) {
+  insist(
+    strategies.length === offerDesc.length &&
+      strategies.length === quantities.length,
+  )`strategies, the offer description, and quantities must be arrays of the same length`;
+
+  const allowedRules = [
+    'offerExactly',
+    'offerAtMost',
+    'wantExactly',
+    'wantAtLeast',
+  ];
+
+  // If we are refunding the player, are their allocated amounts
+  // greater than or equal to what they said they had at the beginning?
+  const refundOk = offerDesc
+    .map((offerDescElem, i) => {
+      if (offerDescElem === null || offerDescElem === undefined) {
+        return true;
+      }
+      insist(
+        allowedRules.includes(offerDescElem.rule),
+      )`The rule ${offerDescElem.rule} was not recognized`;
+      // If the rule was 'offerExactly', we should make sure that the
+      // user gets it back exactly in a refund. If the rule is
+      // 'offerAtMost' we need to ensure that the user gets back the
+      // amount or greater. If the rule is something else, anything
+      // we give back is fine.
+      if (offerDescElem.rule === 'offerExactly') {
+        return strategies[i].equals(
+          quantities[i],
+          offerDescElem.amount.quantity,
+        );
+      }
+      if (offerDesc.rule === 'offerAtMost') {
+        return strategies[i].includes(
+          quantities[i],
+          offerDescElem.amount.quantity,
+        );
+      }
+      return true;
+    })
+    .reduce(bothTrue, true);
+
+  // If we are not refunding the player, are their allocated amounts
+  // greater than or equal to what they said they wanted at the beginning?
+  const winningsOk = offerDesc
+    .map((offerDescElem, i) => {
+      if (offerDescElem === null || offerDescElem === undefined) {
+        return true;
+      }
+      insist(
+        allowedRules.includes(offerDescElem.rule),
+      )`The rule ${offerDescElem.rule} was not recognized`;
+      // If the rule was 'wantExactly', we should make sure that the
+      // user gets exactly the amount specified in their winnings. If
+      // the rule is 'wantAtLeast', we need to ensure that the user
+      // gets back winnings that are equal or greater to the amount.
+      // If the rule is something else, anything we give back is fine.
+      if (offerDescElem.rule === 'wantExactly') {
+        return strategies[i].equals(
+          quantities[i],
+          offerDescElem.amount.quantity,
+        );
+      }
+      if (offerDescElem.rule === 'wantAtLeast') {
+        return strategies[i].includes(
+          quantities[i],
+          offerDescElem.amount.quantity,
+        );
+      }
+      return true;
+    })
+    .reduce(bothTrue, true);
+
+  return refundOk || winningsOk;
+}
+/**
+ * @param  {strategy[]} strategies - an array of strategies ordered in
+ * the same order as the corresponding issuers
+ * @param  {offerDesc[][]} offerDescMatrix - an array of arrays. Each of the
+ * element arrays is the offer description that a single player
+ * made, in the same order as the corresponding issuers.
+ * @param  {quantity[][]} quantityMatrix - an array of arrays. Each of the
+ * element arrays is the array of quantities that a single player will
+ * get, in the same order as the corresponding issuers.
+ */
+const isOfferSafeForAll = (strategies, offerDescMatrix, quantitiesMatrix) =>
+  offerDescMatrix
+    .map((offerDesc, i) =>
+      isOfferSafeForPlayer(strategies, offerDesc, quantitiesMatrix[i]),
+    )
+    .reduce(bothTrue, true);
+
+export { isOfferSafeForPlayer, isOfferSafeForAll };

--- a/core/zoe/utils.js
+++ b/core/zoe/utils.js
@@ -1,0 +1,32 @@
+// used to reduce boolean arrays
+const bothTrue = (prev, curr) => prev && curr;
+const eitherTrue = (prev, curr) => prev || curr;
+
+// https://stackoverflow.com/questions/17428587/transposing-a-2d-array-in-javascript/41772644#41772644
+const transpose = matrix =>
+  matrix.reduce(
+    (acc, row) => row.map((_, i) => [...(acc[i] || []), row[i]]),
+    [],
+  );
+
+const ruleEqual = (leftRule, rightRule) => leftRule.rule === rightRule.rule;
+
+const amountEqual = (assay, leftRule, rightRule) =>
+  assay.equals(leftRule.amount, rightRule.amount);
+
+const offerEqual = (assays, leftOffer, rightOffer) => {
+  const isLengthEqual = leftOffer.length === rightOffer.length;
+  if (!isLengthEqual) {
+    return false;
+  }
+  return leftOffer
+    .map((leftRule, i) => {
+      return (
+        ruleEqual(leftRule, rightOffer[i]) &&
+        amountEqual(assays[i], leftRule, rightOffer[i])
+      );
+    })
+    .reduce(bothTrue, true);
+};
+
+export { bothTrue, eitherTrue, transpose, offerEqual };

--- a/test/unitTests/core/test-seat.js
+++ b/test/unitTests/core/test-seat.js
@@ -2,7 +2,8 @@ import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
 
 import { makeSeatMint } from '../../../core/seatMint';
-import { makeMint } from '../../../core/issuers';
+import { offerEqual } from '../../../core/zoe/utils';
+import { setup } from './zoe/setupBasicMints';
 import { insist } from '../../../util/insist';
 
 /*
@@ -21,48 +22,6 @@ import { insist } from '../../../util/insist';
  * }
  *
  */
-
-const bothTrue = (prev, curr) => prev && curr;
-
-const ruleEqual = (leftRule, rightRule) => leftRule.rule === rightRule.rule;
-
-const amountEqual = (assay, leftRule, rightRule) =>
-  assay.equals(leftRule.amount, rightRule.amount);
-
-const offerEqual = (assays, leftOffer, rightOffer) => {
-  const isLengthEqual = leftOffer.length === rightOffer.length;
-  if (!isLengthEqual) {
-    return false;
-  }
-  return leftOffer
-    .map((leftRule, i) => {
-      return (
-        ruleEqual(leftRule, rightOffer[i]) &&
-        amountEqual(assays[i], leftRule, rightOffer[i])
-      );
-    })
-    .reduce(bothTrue);
-};
-
-const setup = () => {
-  const moolaMint = makeMint('moola');
-  const simoleanMint = makeMint('simoleans');
-  const bucksMint = makeMint('bucks');
-
-  const moolaIssuer = moolaMint.getIssuer();
-  const simoleanIssuer = simoleanMint.getIssuer();
-  const bucksIssuer = bucksMint.getIssuer();
-
-  const moolaAssay = moolaIssuer.getAssay();
-  const simoleanAssay = simoleanIssuer.getAssay();
-  const bucksAssay = bucksIssuer.getAssay();
-
-  return harden({
-    mints: [moolaMint, simoleanMint, bucksMint],
-    issuers: [moolaIssuer, simoleanIssuer, bucksIssuer],
-    assays: [moolaAssay, simoleanAssay, bucksAssay],
-  });
-};
 
 test('seatMint', async t => {
   const { assays } = setup();
@@ -92,7 +51,7 @@ test('seatMint', async t => {
   const purse1Quantity = harden({
     id: harden({}),
     offerToBeMade: [
-      { rule: 'haveExactly', amount: assays[0].make(8) },
+      { rule: 'offerExactly', amount: assays[0].make(8) },
       { rule: 'wantExactly', amount: assays[1].make(6) },
     ],
   });
@@ -113,7 +72,7 @@ test('seatMint', async t => {
   const purse2Quantity = harden({
     id: harden({}),
     offerMade: [
-      { rule: 'haveExactly', amount: assays[0].make(8) },
+      { rule: 'offerExactly', amount: assays[0].make(8) },
       { rule: 'wantExactly', amount: assays[1].make(6) },
     ],
   });

--- a/test/unitTests/core/zoe/setupBasicMints.js
+++ b/test/unitTests/core/zoe/setupBasicMints.js
@@ -1,0 +1,23 @@
+import harden from '@agoric/harden';
+
+import { makeMint } from '../../../../core/issuers';
+
+const setup = () => {
+  const moolaMint = makeMint('moola');
+  const simoleanMint = makeMint('simoleans');
+  const bucksMint = makeMint('bucks');
+
+  const mints = [moolaMint, simoleanMint, bucksMint];
+  const issuers = mints.map(mint => mint.getIssuer());
+  const assays = issuers.map(issuer => issuer.getAssay());
+  const strategies = issuers.map(issuer => issuer.getStrategy());
+
+  return harden({
+    mints,
+    issuers,
+    assays,
+    strategies,
+  });
+};
+harden(setup);
+export { setup };

--- a/test/unitTests/core/zoe/test-areRightsConserved.js
+++ b/test/unitTests/core/zoe/test-areRightsConserved.js
@@ -1,0 +1,51 @@
+import { test } from 'tape-promise/tape';
+
+import { areRightsConserved } from '../../../../core/zoe/areRightsConserved';
+import { setup } from './setupBasicMints';
+
+// rights are conserved for Nat quantities
+test(`areRightsConserved - true for nat quantities`, t => {
+  try {
+    const { issuers } = setup();
+    const strategies = issuers.map(issuer => issuer.getStrategy());
+    const oldQuantities = [[0, 1, 0], [4, 1, 0], [6, 3, 0]];
+    const newQuantities = [[1, 2, 0], [3, 1, 0], [6, 2, 0]];
+
+    t.ok(areRightsConserved(strategies, oldQuantities, newQuantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// rights are *not* conserved for Nat quantities
+test(`areRightsConserved - false for nat quantities`, t => {
+  try {
+    const { issuers } = setup();
+    const strategies = issuers.map(issuer => issuer.getStrategy());
+    const oldQuantities = [[0, 1, 4], [4, 1, 0], [6, 3, 0]];
+    const newQuantities = [[1, 2, 0], [3, 1, 0], [6, 2, 0]];
+
+    t.notOk(areRightsConserved(strategies, oldQuantities, newQuantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test(`areRightsConserved - empty arrays`, t => {
+  try {
+    const { issuers } = setup();
+    const strategies = issuers.map(issuer => issuer.getStrategy());
+    const oldQuantities = [[], [], []];
+    const newQuantities = [[], [], []];
+
+    t.ok(areRightsConserved(strategies, oldQuantities, newQuantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});

--- a/test/unitTests/core/zoe/test-isOfferSafe.js
+++ b/test/unitTests/core/zoe/test-isOfferSafe.js
@@ -1,0 +1,394 @@
+import { test } from 'tape-promise/tape';
+
+import {
+  isOfferSafeForPlayer,
+  isOfferSafeForAll,
+} from '../../../../core/zoe/isOfferSafe';
+import { setup } from './setupBasicMints';
+
+// The player must have offerDesc for each issuer
+test('isOfferSafeForPlayer - empty offerDesc', t => {
+  try {
+    const { strategies } = setup();
+    const offerDesc = [];
+    const quantities = [8, 6, 7];
+
+    t.throws(
+      _ => isOfferSafeForPlayer(strategies, offerDesc, quantities),
+      'strategies, offerDesc, and quantities must be arrays of the same length',
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The quantities array must have an item for each issuer/rule
+test('isOfferSafeForPlayer - empty quantities', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'wantExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+      { rule: 'wantExactly', amount: assays[2].make(7) },
+    ];
+    const quantities = [];
+
+    t.throws(
+      _ => isOfferSafeForPlayer(strategies, offerDesc, quantities),
+      'strategies, offerDesc, and quantities must be arrays of the same length',
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The player puts in something and gets exactly what they wanted,
+// with no refund
+test('isOfferSafeForPlayer - gets wantExactly, with offerExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+      { rule: 'wantExactly', amount: assays[2].make(7) },
+    ];
+    const quantities = [0, 6, 7];
+
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The player gets exactly what they wanted, with no 'have'
+test('isOfferSafeForPlayer - gets wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'wantExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+      { rule: 'wantExactly', amount: assays[2].make(7) },
+    ];
+    const quantities = [8, 6, 7];
+
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The player gets more than what they wanted, with no 'have'. Note:
+// This returns 'true' counterintuitively because no 'have' amount was
+// specified and none were given back, so the refund condition was
+// fulfilled.
+test('isOfferSafeForPlayer - gets wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'wantExactly', amount: assays[0].make(8) },
+      { rule: 'wantExactly', amount: assays[1].make(6) },
+      { rule: 'wantExactly', amount: assays[2].make(7) },
+    ];
+    const quantities = [9, 6, 7];
+
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded exactly what they put in, with a 'wantExactly'
+test(`isOfferSafeForPlayer - gets offerExactly, doesn't get wantExactly`, t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(1) },
+      { rule: 'wantExactly', amount: assays[1].make(2) },
+      { rule: 'offerExactly', amount: assays[2].make(3) },
+    ];
+    const quantities = [1, 0, 3];
+
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded exactly what they put in, with no 'wantExactly'
+test('isOfferSafeForPlayer - gets offerExactly, no wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(1) },
+      { rule: 'offerExactly', amount: assays[1].make(2) },
+      { rule: 'offerExactly', amount: assays[2].make(3) },
+    ];
+    const quantities = [1, 2, 3];
+
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets a refund *and* winnings. This is offer safe.
+test('isOfferSafeForPlayer - refund and winnings', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(3) },
+    ];
+    const quantities = [2, 3, 3];
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets more than they wanted - wantExactly
+test('isOfferSafeForPlayer - more than wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(4) },
+    ];
+    const quantities = [0, 3, 5];
+    t.notOk(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets more than they wanted - wantAtLeast
+test('isOfferSafeForPlayer - more than wantAtLeast', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'wantAtLeast', amount: assays[0].make(2) },
+      { rule: 'wantAtLeast', amount: assays[1].make(3) },
+      { rule: 'wantAtLeast', amount: assays[2].make(4) },
+    ];
+    const quantities = [2, 6, 7];
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded more than what they put in
+test('isOfferSafeForPlayer - more than offerExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'offerExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(4) },
+    ];
+    const quantities = [5, 6, 8];
+    t.notOk(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded more than what they put in, with no
+// wantExactly. Note: This returns 'true' counterintuitively
+// because no winnings were specified and none were given back.
+test('isOfferSafeForPlayer - more than offerExactly, no wants', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'offerExactly', amount: assays[1].make(3) },
+      { rule: 'offerExactly', amount: assays[2].make(4) },
+    ];
+    const quantities = [5, 6, 8];
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded more than what they put in, with 'offerAtMost'
+test('isOfferSafeForPlayer - more than offerAtMost', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerAtMost', amount: assays[0].make(2) },
+      { rule: 'offerAtMost', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(4) },
+    ];
+    const quantities = [5, 3, 0];
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets less than what they wanted - wantExactly
+test('isOfferSafeForPlayer - less than wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(5) },
+    ];
+    const quantities = [0, 2, 1];
+    t.notOk(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets less than what they wanted - wantAtLeast
+test('isOfferSafeForPlayer - less than wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantAtLeast', amount: assays[1].make(3) },
+      { rule: 'wantAtLeast', amount: assays[2].make(9) },
+    ];
+    const quantities = [0, 2, 1];
+    t.notOk(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// The user gets refunded less than they put in
+test('isOfferSafeForPlayer - less than wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantAtLeast', amount: assays[1].make(3) },
+      { rule: 'wantAtLeast', amount: assays[2].make(3) },
+    ];
+    const quantities = [1, 0, 0];
+    t.notOk(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('isOfferSafeForPlayer - empty arrays', t => {
+  try {
+    const { strategies } = setup();
+    const offerDesc = [];
+    const quantities = [];
+    t.throws(
+      () => isOfferSafeForPlayer(strategies, offerDesc, quantities),
+      /strategies, the offer description, and quantities must be arrays of the same length/,
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('isOfferSafeForPlayer - null for some issuers', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      null,
+      { rule: 'offerExactly', amount: assays[2].make(4) },
+    ];
+    const quantities = [5, 6, 8];
+    t.ok(isOfferSafeForPlayer(strategies, offerDesc, quantities));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// All users get exactly what they wanted
+test('isOfferSafeForAll - get wantExactly', t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(3) },
+    ];
+
+    const offerMatrix = [offerDesc, offerDesc, offerDesc];
+    const quantities = [0, 3, 3];
+    const quantitiesMatrix = [quantities, quantities, quantities];
+    t.ok(isOfferSafeForAll(strategies, offerMatrix, quantitiesMatrix));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+// One user doesn't get what they wanted
+test(`isOfferSafeForAll - get wantExactly - one doesn't`, t => {
+  try {
+    const { strategies, assays } = setup();
+    const offerDesc = [
+      { rule: 'offerExactly', amount: assays[0].make(2) },
+      { rule: 'wantExactly', amount: assays[1].make(3) },
+      { rule: 'wantExactly', amount: assays[2].make(3) },
+    ];
+
+    const offerMatrix = [offerDesc, offerDesc, offerDesc];
+    const quantities = [0, 3, 3];
+    const unsatisfiedUserquantities = [
+      assays[0].make(0),
+      assays[1].make(3),
+      assays[2].make(2),
+    ];
+    const quantitiesMatrix = [
+      quantities,
+      quantities,
+      unsatisfiedUserquantities,
+    ];
+    t.notOk(isOfferSafeForAll(strategies, offerMatrix, quantitiesMatrix));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});

--- a/test/unitTests/core/zoe/test-utils.js
+++ b/test/unitTests/core/zoe/test-utils.js
@@ -1,0 +1,230 @@
+import { test } from 'tape-promise/tape';
+
+import {
+  bothTrue,
+  eitherTrue,
+  transpose,
+  offerEqual,
+} from '../../../../core/zoe/utils';
+import { setup } from './setupBasicMints';
+
+test('bothTrue', t => {
+  try {
+    t.ok([1, 2].reduce(bothTrue));
+    t.ok([].reduce(bothTrue, true));
+    t.notOk([false, 2].reduce(bothTrue));
+    t.notOk([false, false].reduce(bothTrue));
+    t.ok([true, true].reduce(bothTrue));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('eitherTrue', t => {
+  try {
+    t.ok([1, 2].reduce(eitherTrue));
+    t.ok([].reduce(eitherTrue, true));
+    t.ok([false, 2].reduce(eitherTrue));
+    t.notOk([false, false].reduce(eitherTrue));
+    t.ok([true, true].reduce(eitherTrue));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('transpose', t => {
+  try {
+    t.deepEquals(transpose([[1, 2, 3], [4, 5, 6]]), [[1, 4], [2, 5], [3, 6]]);
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('offerEqual - offers are equal', t => {
+  const { issuers, assays } = setup();
+  try {
+    const offer1 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    t.ok(offerEqual(assays, offer1, offer1));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('offerEqual - throws bc offers have different issuers', t => {
+  const { issuers, assays } = setup();
+  try {
+    const offer1 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    const offer2 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[1].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[0].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    // This throws because the assay does not recognize the amounts
+    // for a different issuer
+    t.throws(() => offerEqual(assays, offer1, offer2), /Unrecognized label/);
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('offerEqual - returns false bc different quantity', t => {
+  const { issuers, assays } = setup();
+  try {
+    const offer1 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    const offer2 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(4),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    t.notOk(offerEqual(assays, offer1, offer2));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('offerEqual - returns false bc different rule', t => {
+  const { issuers, assays } = setup();
+  try {
+    const offer1 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    const offer2 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'offerExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    t.notOk(offerEqual(assays, offer1, offer2));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('offerEqual - wantExactly vs wantAtLeast - returns false', t => {
+  const { issuers, assays } = setup();
+  try {
+    const offer1 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    const offer2 = [
+      {
+        rule: 'offerExactly',
+        amount: issuers[0].makeAmount(3),
+      },
+      {
+        rule: 'wantExactly',
+        amount: issuers[1].makeAmount(7),
+      },
+      {
+        rule: 'wantAtLeast',
+        amount: issuers[2].makeAmount(7),
+      },
+    ];
+    t.notOk(offerEqual(assays, offer1, offer2));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
This PR is part of the Zoe implementation. It adds helper functions for determining whether a reallocation of quantities conserves rights (has the same total quantity per issuer) and whether a reallocation is "offer-safe" for each user. 