### PR TITLE
Chainmail typos

### DIFF
--- a/core/issuers.chainmail
+++ b/core/issuers.chainmail
@@ -25,8 +25,8 @@ interface Issuer (Amount (Quantity)) {
   makeEmptyPurse(name :String) -> (Purse);
 
   /** Combine multiple payments into one payment. */
-  combine(paymentsArray :List(Payment), 
-  name :String = 'combined payment') -> (Payment);
+  combine(paymentsArray :List(Payment), name :String = 'combined payment')
+    -> (Payment);
 
   /** 
    * Split a single payment into multiple payments, according to the

--- a/core/issuers.chainmail
+++ b/core/issuers.chainmail
@@ -26,15 +26,14 @@ interface Issuer (Amount (Quantity)) {
 
   /** Combine multiple payments into one payment. */
   combine(paymentsArray :List(Payment), 
-  name :String = 'combined payment') -> (Payment)
+  name :String = 'combined payment') -> (Payment);
 
   /** 
    * Split a single payment into multiple payments, according to the
    * amounts and names passed in. 
    */
-  split(payment, amountsArray :List(Amount), namesArray
-  :List(String))
-    -> (List(Payment))
+  split(payment :Payment, amountsArray :List(Amount), namesArray :List(String))
+    -> (List(Payment));
 
   /**
    * Make a new Payment that has exclusive rights to all the contents


### PR DESCRIPTION
A missing semicolon, and a missing type declaration.

In case this hasn't been documented previously, you can run chainmail with
```
git clone -b chainmail https://github.com/Agoric/jessica
npm install
jessica/lang/nodejs/cmparse.bat [single .chainmail file]
```