### PR TITLE
add getTotalSupply() method

### DIFF
--- a/core/config/totalSupplyConfig.js
+++ b/core/config/totalSupplyConfig.js
@@ -1,0 +1,32 @@
+import harden from '@agoric/harden';
+
+import { noCustomization } from './noCustomization';
+import { makeTotalSupplyMintKeeper } from './totalSupplyMintKeeper';
+import { natStrategy } from './strategies/natStrategy';
+
+// This fungible token configuration uses a custom mintKeeper to keep
+// track of the total supply of tokens. Note that it is possible for
+// references to purses and payments to be dropped and garbage
+// collected without the total supply decreasing. Thus, the total
+// supply is an upper bound. This configuration uses the "Nat" strategy,
+// in which amounts are natural numbers and use subtraction and
+// addition.
+
+// This configuration and others like it are passed into `makeMint` in
+// `issuers.js`.
+const makeTotalSupplyConfig = () => {
+  function* makeMintTrait(_superMint, _issuer, _assay, mintKeeper) {
+    return yield harden({
+      getTotalSupply: () => mintKeeper.getTotalSupply(),
+    });
+  }
+
+  return harden({
+    ...noCustomization,
+    makeMintKeeper: makeTotalSupplyMintKeeper,
+    strategy: natStrategy,
+    makeMintTrait,
+  });
+};
+
+export { makeTotalSupplyConfig };

--- a/core/config/totalSupplyMintKeeper.js
+++ b/core/config/totalSupplyMintKeeper.js
@@ -1,0 +1,61 @@
+import harden from '@agoric/harden';
+
+import { makePrivateName } from '../../util/PrivateName';
+
+export function makeTotalSupplyMintKeeper(assay) {
+  let totalSupply = assay.empty();
+
+  // An asset can either be a purse or payment. An asset keeper
+  // keeps track of either all of the purses (purseKeeper) or all
+  // of the payments (paymentKeeper) and their respective amounts.
+  function makeAssetKeeper() {
+    // asset to amount
+    const amounts = makePrivateName();
+    return harden({
+      updateAmount(asset, newAmount) {
+        const oldAmount = amounts.get(asset);
+        amounts.set(asset, newAmount);
+        // if old amount includes new, then it's a decrease
+        if (assay.includes(oldAmount, newAmount)) {
+          const decrease = assay.without(oldAmount, newAmount);
+          totalSupply = assay.without(totalSupply, decrease);
+        } else {
+          // otherwise it's an increase
+          const increase = assay.without(newAmount, oldAmount);
+          totalSupply = assay.with(totalSupply, increase);
+        }
+      },
+      recordNew(asset, initialAmount) {
+        amounts.init(asset, initialAmount);
+        totalSupply = assay.with(totalSupply, initialAmount);
+      },
+      getAmount(asset) {
+        return amounts.get(asset);
+      },
+      has(asset) {
+        return amounts.has(asset);
+      },
+      remove(asset) {
+        const amount = amounts.get(asset);
+        totalSupply = assay.without(totalSupply, amount);
+        amounts.delete(asset);
+      },
+    });
+  }
+
+  const purseKeeper = makeAssetKeeper();
+  const paymentKeeper = makeAssetKeeper();
+
+  const mintKeeper = harden({
+    purseKeeper,
+    paymentKeeper,
+    isPurse(asset) {
+      return purseKeeper.has(asset);
+    },
+    isPayment(asset) {
+      return paymentKeeper.has(asset);
+    },
+    getTotalSupply: () => totalSupply,
+  });
+  return mintKeeper;
+}

--- a/core/issuers.js
+++ b/core/issuers.js
@@ -219,13 +219,20 @@ Description must be truthy: ${description}`;
     },
 
     burnExactly(amount, srcPaymentP) {
-      const sinkPurse = coreIssuer.makeEmptyPurse('sink purse');
-      return sinkPurse.depositExactly(amount, srcPaymentP);
+      return Promise.resolve(srcPaymentP).then(srcPayment => {
+        insistAmountEqualsPaymentBalance(amount, srcPayment);
+        const paymentAmount = paymentKeeper.getAmount(srcPayment);
+        paymentKeeper.remove(srcPayment);
+        return paymentAmount;
+      });
     },
 
     burnAll(srcPaymentP) {
-      const sinkPurse = coreIssuer.makeEmptyPurse('sink purse');
-      return sinkPurse.depositAll(srcPaymentP);
+      return Promise.resolve(srcPaymentP).then(srcPayment => {
+        const amount = paymentKeeper.getAmount(srcPayment);
+        paymentKeeper.remove(srcPayment);
+        return amount;
+      });
     },
   });
 

--- a/test/unitTests/core/test-totalSupplyMintKeeper.js
+++ b/test/unitTests/core/test-totalSupplyMintKeeper.js
@@ -1,0 +1,29 @@
+import { test } from 'tape-promise/tape';
+import { makeMint } from '../../../core/issuers';
+import { makeTotalSupplyConfig } from '../../../core/config/totalSupplyConfig';
+
+test('totalSupplyConfig', async t => {
+  try {
+    const mint = makeMint('liquidityTokens', makeTotalSupplyConfig);
+    const issuer = mint.getIssuer();
+    const purse1 = await mint.mint(1000);
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(1000));
+    const purse2 = await mint.mint(532);
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(1532));
+    const payment1 = await purse1.withdrawAll();
+    t.deepEquals(payment1.getBalance(), issuer.makeAmount(1000));
+    const payment2 = await purse2.withdraw(issuer.makeAmount(10));
+    t.deepEquals(payment2.getBalance(), issuer.makeAmount(10));
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(1532));
+    await issuer.burnAll(payment1);
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(532));
+    await mint.mint(4);
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(536));
+    await issuer.burnExactly(issuer.makeAmount(10), payment2);
+    t.deepEquals(mint.getTotalSupply(), issuer.makeAmount(526));
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Our autoswap implementation benefits from being able to find out the current supply of the liquidity token. It uses the current supply to calculate how many liquidity tokens should be minted when liquidity is added, and how much underlying liquidity should be given back when liquidity is removed and the liquidity tokens are burned. 

This PR adds a custom configuration that can be passed to `makeMint`. The custom configuration, if used when making a mint, adds a method to the `mint` object called `getTotalSupply`, which returns an amount representing the total amount in purses and payments. 

The total supply is calculated in a custom `mintKeeper` called the `totalSupplyMintKeeper`. Whenever the amount of a purse or payment is updated, it alters the `totalSupply` variable within the `mintKeeper`. 

I think we could easily extend this in the future to create a mint that is credibly capped to a certain supply.