### PR TITLE
Registrar service

### DIFF
--- a/more/registrar/registrar.js
+++ b/more/registrar/registrar.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from "@agoric/harden";
+import { insist } from "../../util/insist";
+import { generateSparseInts } from "../../util/sparseInts";
+
+// Example REPL imnvocations
+// home.registrar~.register('handoff', home.handoffService)
+// for (let i = 0; i < 3000; i++) { home.registrar~.register('handoff', home.handoffService); }
+
+// Generated keys must end with _ and digits.
+const keyFormat = new RegExp('.*_[0-9]+');
+
+function makeRegistrar(systemVersion, seed = 0) {
+  // TODO make a better token algorithm.
+  const useCounts = new Map();
+  const contents = new Map();
+  const sparseInts = generateSparseInts(seed);
+
+  const registrar = harden({
+    // Register the value
+    register(name, value) {
+      const realName = name.toLowerCase();
+      const useCount = (useCounts.get(realName) || 0) + 1;
+      useCounts.set(realName, useCount);
+      const depth = Math.max(4, Math.floor(Math.log10(useCount) + 1.6));
+      const uniqueString = sparseInts.next().value.toString();
+      const keyString = uniqueString.slice(-depth).padStart(depth, '0');
+      // console.log(`RAND ${useCount} ${uniqueString} ${keyString}`);
+      const key = `${realName}_${keyString}`;
+      // if it was a random keyString, then we need to detect collision
+      insist(!contents.has(key), 'Generated name must not collide');
+      contents.set(key, value);
+      return key;
+    },
+    get(key, version = null) {
+      insist(typeof key === 'string')`\
+Key must be string ${key}`;
+      insist(keyFormat.test(key))`\
+Key must end with _<digits> ${key}`
+      if (version) {
+        insist(version === systemVersion)`\
+Key is from incompatible version: ${version} should be ${systemVersion}`;
+      }
+      return contents.get(key);
+    },
+    keys() {
+      return contents.keys();
+    },
+  });
+
+  return registrar;
+}
+
+export { makeRegistrar };

--- a/more/registrar/registrar.js
+++ b/more/registrar/registrar.js
@@ -24,12 +24,16 @@ function makeRegistrar(systemVersion, seed = 0) {
       const useCount = (useCounts.get(realName) || 0) + 1;
       useCounts.set(realName, useCount);
       const depth = Math.max(4, Math.floor(Math.log10(useCount) + 1.6));
-      const uniqueString = sparseInts.next().value.toString();
-      const keyString = uniqueString.slice(-depth).padStart(depth, '0');
-      // console.log(`RAND ${useCount} ${uniqueString} ${keyString}`);
-      const key = `${realName}_${keyString}`;
-      // if it was a random keyString, then we need to detect collision
-      insist(!contents.has(key), 'Generated name must not collide');
+
+      // Retry until we have a unique key.
+      let key;
+      do {
+        const uniqueString = sparseInts.next().value.toString();
+        const keyString = uniqueString.slice(-depth).padStart(depth, '0');
+        // console.log(`RAND ${useCount} ${uniqueString} ${keyString}`);
+        key = `${realName}_${keyString}`;
+      } while (contents.has(key));
+
       contents.set(key, value);
       return key;
     },

--- a/test/unitTests/more/registrar/test-registrar.js
+++ b/test/unitTests/more/registrar/test-registrar.js
@@ -1,0 +1,32 @@
+import { test } from 'tape-promise/tape';
+import { makeRegistrar } from '../../../../more/registrar/registrar';
+
+test('Registrar creation', async t => {
+  try {
+    const registrarService = makeRegistrar('testnet');
+    const obj1 = {};
+    const obj2 = {};
+    const id1 = registrarService.register('myname', obj1);
+    t.assert(id1.match(/^myname_\d{4,}$/), 'id1 is correct format')
+    const id2 = registrarService.register('myname', obj2);
+    t.assert(id2.match(/^myname_\d{4,}$/), 'id2 is correct format')
+    t.isNot(id2, id1, 'ids for different objects are different');
+    const id1a = registrarService.register('myname', obj1);
+    t.assert(id1a.match(/^myname_\d{4,}$/), 'id1a is correct format')
+    t.isNot(id1a, id1, 'ids for same object are different');
+    const id1b = registrarService.register('othername', obj1);
+    t.assert(id1b.match(/^othername_\d{4,}$/), 'id1b is correct format')
+    const ret1 = registrarService.get(id1);
+    t.equals(ret1, obj1, 'returned obj1 is equal');
+    const ret2 = registrarService.get(id2);
+    t.equals(ret2, obj2, 'returned obj2 is equal');
+    const ret1a = registrarService.get(id1a);
+    t.equals(ret1a, obj1, 'returned obj1a is equal');
+    const ret1b = registrarService.get(id1b);
+    t.equals(ret1b, obj1, 'returned obj1b is equal');
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});

--- a/test/unitTests/more/registrar/test-registrar.js
+++ b/test/unitTests/more/registrar/test-registrar.js
@@ -1,21 +1,21 @@
 import { test } from 'tape-promise/tape';
 import { makeRegistrar } from '../../../../more/registrar/registrar';
 
-test('Registrar creation', async t => {
+test('Registrar operations', async t => {
   try {
     const registrarService = makeRegistrar('testnet');
     const obj1 = {};
     const obj2 = {};
     const id1 = registrarService.register('myname', obj1);
-    t.assert(id1.match(/^myname_\d{4,}$/), 'id1 is correct format')
+    t.assert(id1.match(/^myname_\d{4,}$/), 'id1 is correct format');
     const id2 = registrarService.register('myname', obj2);
-    t.assert(id2.match(/^myname_\d{4,}$/), 'id2 is correct format')
+    t.assert(id2.match(/^myname_\d{4,}$/), 'id2 is correct format');
     t.isNot(id2, id1, 'ids for different objects are different');
     const id1a = registrarService.register('myname', obj1);
-    t.assert(id1a.match(/^myname_\d{4,}$/), 'id1a is correct format')
+    t.assert(id1a.match(/^myname_\d{4,}$/), 'id1a is correct format');
     t.isNot(id1a, id1, 'ids for same object are different');
     const id1b = registrarService.register('othername', obj1);
-    t.assert(id1b.match(/^othername_\d{4,}$/), 'id1b is correct format')
+    t.assert(id1b.match(/^othername_\d{4,}$/), 'id1b is correct format');
     const ret1 = registrarService.get(id1);
     t.equals(ret1, obj1, 'returned obj1 is equal');
     const ret2 = registrarService.get(id2);
@@ -24,6 +24,34 @@ test('Registrar creation', async t => {
     t.equals(ret1a, obj1, 'returned obj1a is equal');
     const ret1b = registrarService.get(id1b);
     t.equals(ret1b, obj1, 'returned obj1b is equal');
+
+    t.equals(registrarService.keys().length, 4, 'number of keys is expected');
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
+
+test.only('Registrar collisions', async t => {
+  try {
+    const registrarService = makeRegistrar('collide');
+    const iterations = 3000;
+    const myobj = {};
+    let maxlength = Number.NEGATIVE_INFINITY;
+    for (let i = 0; i < iterations; i += 1) {
+      const id = registrarService.register('a', myobj);
+      maxlength = Math.max(maxlength, id.length);
+    }
+    t.equals(maxlength, 7, 'expected maximum key length');
+
+    const keys = registrarService.keys();
+    t.equals(keys.length, iterations, 'expected number of keys');
+    t.equals(
+      keys.filter(key => registrarService.get(key) !== myobj).length,
+      0,
+      'expected no deviations',
+    );
   } catch (e) {
     t.isNot(e, e, 'unexpected exception');
   } finally {

--- a/test/unitTests/more/registrar/test-registrar.js
+++ b/test/unitTests/more/registrar/test-registrar.js
@@ -33,7 +33,7 @@ test('Registrar operations', async t => {
   }
 });
 
-test.only('Registrar collisions', async t => {
+test('Registrar collisions', async t => {
   try {
     const registrarService = makeRegistrar('collide');
     const iterations = 3000;

--- a/util/sparseInts.js
+++ b/util/sparseInts.js
@@ -1,7 +1,6 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import harden from '@agoric/harden';
-import { insist } from "./insist";
 
 // Generator function to produce a stream of positive integers that are
 // sparsely scattered across the number space. This supports IDs that

--- a/util/sparseInts.js
+++ b/util/sparseInts.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Agoric, under Apache License 2.0
+
+import harden from '@agoric/harden';
+import { insist } from "./insist";
+
+// Generator function to produce a stream of positive integers that are
+// sparsely scattered across the number space. This supports IDs that
+// are guessable, but for example mistyping a correct ID is unlikely to
+// mistakenly match another generated ID.
+function* generateSparseInts(seed) {
+  // This is a linear-feedback shift register with computed startState.
+  // Thus, it is totally deterministic, but at least looks a little random
+  // and so can be used for e.g., colors in a game or the gallery
+
+  /* eslint-disable no-bitwise */
+  const mask = 0xffffffff;
+  const startState = Math.floor(seed * mask) ^ 0xdeadbeef;
+  let lfsr = startState;
+  while (true) {
+    lfsr ^= lfsr >>> 7;
+    lfsr ^= (lfsr << 9) & mask;
+    lfsr ^= lfsr >>> 13;
+    const rand = (Math.floor(lfsr) % 0x800000) + 0x7fffff;
+    yield rand;
+  }
+  /* eslint-enable no-bitwise */
+}
+harden(generateSparseInts);
+export { generateSparseInts };


### PR DESCRIPTION
~~PR FOR DISCUSSION ONLY~~

This illustrates the registrar naming service. You register an object with a key prefix, and it returns the key, of the form `<prefix>_<digits>`. The `digits` are from an integer in a sparse distribution. the distribution is deterministic, but this helps protect against typos resulting in generating another valid key.

```
command[0] home.registrar~.register('handoff', home.handoffService)
history[0] "handoff_4409"

command[1] home.registrar~.get('handoff')
history[1] Promise.reject("Error: Key must end with _<digits> (a string)\nSee console for error data.")

command[2] home.registrar~.get('handoff_4409')
history[2] [Presence o-51]

command[3] history[2] === home.handoffService
history[3] true
```

Outstanding issues:
- ~~no tests~~
- no iteration (may not be required)
- it uses `get` rather than simple property lookup (which requires a proxy)