### PR TITLE
feat(zoe): allow specifying additional endowments for contracts

### DIFF
--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -15,8 +15,14 @@ import { makeInviteConfig } from './config/inviteConfig';
 import { makeMint } from './mint';
 import makePromise from '../util/makePromise';
 
-/** Make a reusable host that can reliably install and execute contracts. */
-function makeContractHost(E, evaluate, endowments = {}) {
+/**
+ * Make a reusable host that can reliably install and execute contracts.
+ *
+ * @param E eventual-send method proxy
+ * @param evaluate function to evaluate with endowments
+ * @param additionalEndowments pure or pure-ish endowments to add to evaluator
+ */
+function makeContractHost(E, evaluate, additionalEndowments = {}) {
   // Maps from seat identity to seats
   const seats = makePrivateName();
   // from seat identity to invite description.
@@ -55,7 +61,7 @@ No invites left`;
   };
   const fullEndowments = Object.create(null, {
     ...Object.getOwnPropertyDescriptors(defaultEndowments),
-    ...Object.getOwnPropertyDescriptors(endowments),
+    ...Object.getOwnPropertyDescriptors(additionalEndowments),
   });
 
   function evaluateStringToFn(functionSrcString) {

--- a/core/contractHost.js
+++ b/core/contractHost.js
@@ -16,7 +16,7 @@ import { makeMint } from './mint';
 import makePromise from '../util/makePromise';
 
 /** Make a reusable host that can reliably install and execute contracts. */
-function makeContractHost(E, evaluate) {
+function makeContractHost(E, evaluate, endowments = {}) {
   // Maps from seat identity to seats
   const seats = makePrivateName();
   // from seat identity to invite description.
@@ -40,20 +40,28 @@ No invites left`;
     ).then(_ => seats.get(seatIdentity));
   }
 
+  const defaultEndowments = {
+    Nat,
+    harden,
+    console,
+    E,
+    makePromise,
+    // TODO: sameStructure is used in one check...() function. Figure out a
+    // more general approach to providing useful helpers.
+    // The best approach is to use the `getExport` moduleFormat, and
+    // bundle imported modules that implement the things we want to use.
+    sameStructure,
+    mustBeSameStructure,
+  };
+  const fullEndowments = Object.create(null, {
+    ...Object.getOwnPropertyDescriptors(defaultEndowments),
+    ...Object.getOwnPropertyDescriptors(endowments),
+  });
+
   function evaluateStringToFn(functionSrcString) {
     insist(typeof functionSrcString === 'string')`\n
 "${functionSrcString}" must be a string, but was ${typeof functionSrcString}`;
-    const fn = evaluate(functionSrcString, {
-      Nat,
-      harden,
-      console,
-      E,
-      makePromise,
-      // TODO: sameStructure is used in one check...() function. Figure out a
-      // more general approach to providing useful helpers.
-      sameStructure,
-      mustBeSameStructure,
-    });
+    const fn = evaluate(functionSrcString, fullEndowments);
     insist(typeof fn === 'function')`\n
 "${functionSrcString}" must be a string for a function, but produced ${typeof fn}`;
     return fn;

--- a/core/zoe/zoe/zoe.js
+++ b/core/zoe/zoe/zoe.js
@@ -21,7 +21,7 @@ import { makeSeatMint } from '../../seatMint';
 import { makeEscrowReceiptConfig } from './escrowReceiptConfig';
 import { makeMint } from '../../mint';
 
-const makeZoe = async () => {
+const makeZoe = async (endowments = {}) => {
   // The escrowReceiptAssay is a long-lived identity over many
   // contract instances
   const {
@@ -42,14 +42,19 @@ const makeZoe = async () => {
   );
   const escrowReceiptAssay = escrowReceiptMint.getAssay();
 
+  const defaultEndowments = {
+    harden,
+    makePromise,
+    insist,
+  };
+  const fullEndowments = Object.create(null, {
+    ...Object.getOwnPropertyDescriptors(defaultEndowments),
+    ...Object.getOwnPropertyDescriptors(endowments),
+  });
   const evaluateStringToFn = functionSrcString => {
     insist(typeof functionSrcString === 'string')`\n
 "${functionSrcString}" must be a string, but was ${typeof functionSrcString}`;
-    const fn = evaluate(functionSrcString, {
-      harden,
-      makePromise,
-      insist,
-    });
+    const fn = evaluate(functionSrcString, fullEndowments);
     insist(typeof fn === 'function')`\n
 "${functionSrcString}" must be a string for a function, but produced ${typeof fn}`;
     return fn;

--- a/core/zoe/zoe/zoe.js
+++ b/core/zoe/zoe/zoe.js
@@ -21,7 +21,12 @@ import { makeSeatMint } from '../../seatMint';
 import { makeEscrowReceiptConfig } from './escrowReceiptConfig';
 import { makeMint } from '../../mint';
 
-const makeZoe = async (endowments = {}) => {
+/**
+ * Create an instance of Zoe.
+ *
+ * @param additionalEndowments pure or pure-ish endowments to add to evaluator
+ */
+const makeZoe = async (additionalEndowments = {}) => {
   // The escrowReceiptAssay is a long-lived identity over many
   // contract instances
   const {
@@ -49,7 +54,7 @@ const makeZoe = async (endowments = {}) => {
   };
   const fullEndowments = Object.create(null, {
     ...Object.getOwnPropertyDescriptors(defaultEndowments),
-    ...Object.getOwnPropertyDescriptors(endowments),
+    ...Object.getOwnPropertyDescriptors(additionalEndowments),
   });
   const evaluateStringToFn = functionSrcString => {
     insist(typeof functionSrcString === 'string')`\n


### PR DESCRIPTION
This is also added to the contractHost, so that SwingSet users
can endow a `require` function for bundled contract code in the
`getExport` module format.