### PR TITLE
Change default exit condition in Zoe contract tests to "onDemand"

### DIFF
--- a/core/zoe/contracts/publicSwap.js
+++ b/core/zoe/contracts/publicSwap.js
@@ -97,6 +97,3 @@ const publicSwapSrcs = harden({
 });
 
 export { publicSwapSrcs };
-
-// eslint-disable-next-line spaced-comment
-//# sourceURL=publicSwap.js

--- a/core/zoe/zoe/zoeUtils.js
+++ b/core/zoe/zoe/zoeUtils.js
@@ -71,7 +71,7 @@ const insistValidRules = offerDesc => {
 
 const insistValidExitCondition = exit => {
   const acceptedExitConditionKinds = [
-    'noExit',
+    'onDemand',
     'onDemand',
     'afterDeadline',
     // 'onDemandAfterDeadline', // not yet supported
@@ -148,6 +148,11 @@ const makePayments = (purses, assetDescsMatrix) => {
 
 // Note: offerIds must be for the same assays.
 const completeOffers = async (adminState, readOnlyState, offerIds) => {
+  const { inactive } = readOnlyState.getStatusFor(offerIds);
+  if (inactive.length > 0) {
+    throw new Error('offer has already completed');
+  }
+  adminState.setOffersAsInactive(offerIds);
   const [assays] = readOnlyState.getAssaysFor(offerIds);
   const extents = readOnlyState.getExtentsFor(offerIds);
   const extentOps = readOnlyState.getExtentOpsArrayForAssays(assays);

--- a/test/swingsetTests/zoe/test-zoe.js
+++ b/test/swingsetTests/zoe/test-zoe.js
@@ -18,8 +18,8 @@ async function main(withSES, basedir, argv) {
 const expectedAutomaticRefundOkLog = [
   '=> alice, bob, carol and dave are set up',
   '=> alice.doCreateAutomaticRefund called',
-  '{"offerDesc":[{"rule":"offerExactly","assetDesc":{"label":{"assay":{},"description":"moola"},"extent":3}},{"rule":"wantExactly","assetDesc":{"label":{"assay":{},"description":"simoleans"},"extent":7}}],"exit":{"kind":"noExit"}}',
-  '{"offerDesc":[{"rule":"wantExactly","assetDesc":{"label":{"assay":{},"description":"moola"},"extent":15}},{"rule":"offerExactly","assetDesc":{"label":{"assay":{},"description":"simoleans"},"extent":17}}],"exit":{"kind":"noExit"}}',
+  '{"offerDesc":[{"rule":"offerExactly","assetDesc":{"label":{"assay":{},"description":"moola"},"extent":3}},{"rule":"wantExactly","assetDesc":{"label":{"assay":{},"description":"simoleans"},"extent":7}}],"exit":{"kind":"onDemand"}}',
+  '{"offerDesc":[{"rule":"wantExactly","assetDesc":{"label":{"assay":{},"description":"moola"},"extent":15}},{"rule":"offerExactly","assetDesc":{"label":{"assay":{},"description":"simoleans"},"extent":17}}],"exit":{"kind":"onDemand"}}',
   'bobMoolaPurse: balance {"label":{"assay":{},"description":"moola"},"extent":0}',
   'bobSimoleanPurse;: balance {"label":{"assay":{},"description":"simoleans"},"extent":17}',
   'aliceMoolaPurse: balance {"label":{"assay":{},"description":"moola"},"extent":3}',

--- a/test/swingsetTests/zoe/vat-alice.js
+++ b/test/swingsetTests/zoe/vat-alice.js
@@ -35,7 +35,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
 
@@ -82,7 +82,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
 
@@ -129,7 +129,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const moolaPayment = await E(moolaPurseP).withdrawAll();
@@ -181,7 +181,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const moolaPayment = await E(moolaPurseP).withdrawAll();
@@ -232,7 +232,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const moolaPayment = await E(moolaPurseP).withdrawAll();

--- a/test/swingsetTests/zoe/vat-bob.js
+++ b/test/swingsetTests/zoe/vat-bob.js
@@ -50,7 +50,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
 
@@ -102,7 +102,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
 
@@ -178,7 +178,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
       const simoleanPayment = await E(simoleanPurseP).withdrawAll();
@@ -225,7 +225,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
       const simoleanPayment = await E(simoleanPurseP).withdrawAll();
@@ -276,7 +276,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
       const simoleanPayment = await E(simoleanPurseP).withdrawAll();

--- a/test/swingsetTests/zoe/vat-carol.js
+++ b/test/swingsetTests/zoe/vat-carol.js
@@ -39,7 +39,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
       const simoleanPayment = await E(simoleanPurseP).withdrawAll();
@@ -82,7 +82,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
 

--- a/test/swingsetTests/zoe/vat-dave.js
+++ b/test/swingsetTests/zoe/vat-dave.js
@@ -39,7 +39,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           },
         ],
         exit: {
-          kind: 'noExit',
+          kind: 'onDemand',
         },
       });
       const simoleanPayment = await E(simoleanPurseP).withdrawAll();

--- a/test/unitTests/core/zoe/contracts/test-coveredCall.js
+++ b/test/unitTests/core/zoe/contracts/test-coveredCall.js
@@ -49,7 +49,7 @@ test('zoe - coveredCall', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const alicePayments = [aliceMoolaPayment, undefined];
@@ -106,7 +106,7 @@ test('zoe - coveredCall', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
 
@@ -294,7 +294,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
 
@@ -333,7 +333,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     // 8: Bob makes an offer with his escrow receipt
     t.rejects(
       bobInvite.makeOffer(bobEscrowReceipt),
-      /The offer was invalid or the contract is not accepting offers. Please check your refund./,
+      /The first offer was withdrawn/,
     );
 
     t.equals(

--- a/test/unitTests/core/zoe/contracts/test-publicAuction.js
+++ b/test/unitTests/core/zoe/contracts/test-publicAuction.js
@@ -56,7 +56,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const alicePayments = [aliceMoolaPayment, undefined];
@@ -103,7 +103,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const bobPayments = [undefined, bobSimoleanPayment];
@@ -151,7 +151,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const carolPayments = [undefined, carolSimoleanPayment];
@@ -191,7 +191,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const davePayments = [undefined, daveSimoleanPayment];
@@ -388,7 +388,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const bobPayments = [undefined, bobSimoleanPayment];
@@ -434,7 +434,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const carolPayments = [undefined, carolSimoleanPayment];
@@ -472,7 +472,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const davePayments = [undefined, daveSimoleanPayment];

--- a/test/unitTests/core/zoe/contracts/test-publicSwap.js
+++ b/test/unitTests/core/zoe/contracts/test-publicSwap.js
@@ -47,7 +47,7 @@ test('zoe - publicSwap', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const alicePayments = [aliceMoolaPayment, undefined];
@@ -103,7 +103,7 @@ test('zoe - publicSwap', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const bobPayments = [undefined, bobSimoleanPayment];

--- a/test/unitTests/core/zoe/contracts/test-simpleExchange.js
+++ b/test/unitTests/core/zoe/contracts/test-simpleExchange.js
@@ -45,7 +45,7 @@ test('zoe - simpleExchange', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const alicePayments = [aliceMoolaPayment, undefined];
@@ -90,7 +90,7 @@ test('zoe - simpleExchange', async t => {
         },
       ],
       exit: {
-        kind: 'noExit',
+        kind: 'onDemand',
       },
     });
     const bobPayments = [undefined, bobSimoleanPayment];


### PR DESCRIPTION
Most of the time, users will use the exit condition "onDemand", which will allow them to cancel at will. This PR changes the exit condition used by default in tests to match this, rather than the previous choice, "noExit". 

This PR adds more tests and also alters most of the governing contracts to better check for exit. A few more still need to be done.