### PR TITLE
Change Zoe Contracts to be compatible with "@agoric/bundle-source"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /dist
 /src/bundles/
+/test/swingsetTests/zoe/bundle-*.js

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 .idea/
+bundle-*.js

--- a/core/zoe/contracts/automaticRefund.js
+++ b/core/zoe/contracts/automaticRefund.js
@@ -9,7 +9,7 @@ import harden from '@agoric/harden';
  * @param {governingContractFacet} zoe - the governing
  * contract facet of zoe
  */
-const makeContract = (zoe, terms) => {
+export const makeContract = harden((zoe, terms) => {
   let count = 0;
   const automaticRefund = harden({
     makeOffer: async escrowReceipt => {
@@ -24,10 +24,4 @@ const makeContract = (zoe, terms) => {
     instance: automaticRefund,
     assays: terms.assays,
   });
-};
-
-const automaticRefundSrcs = harden({
-  makeContract: `${makeContract}`,
 });
-
-export { automaticRefundSrcs };

--- a/core/zoe/contracts/autoswap.js
+++ b/core/zoe/contracts/autoswap.js
@@ -361,9 +361,3 @@ export const makeContract = harden((zoe, terms) => {
     assays,
   });
 });
-
-const autoswapSrcs = harden({
-  makeContract: `${makeContract}`,
-});
-
-export { autoswapSrcs };

--- a/core/zoe/contracts/coveredCall.js
+++ b/core/zoe/contracts/coveredCall.js
@@ -3,7 +3,7 @@ import harden from '@agoric/harden';
 import { insist } from '../../../util/insist';
 import { sameStructure } from '../../../util/sameStructure';
 
-const makeContract = harden((zoe, terms) => {
+export const makeContract = harden((zoe, terms) => {
   let firstOfferId;
   let matchingOfferId;
 
@@ -149,9 +149,3 @@ const makeContract = harden((zoe, terms) => {
     assays: terms.assays,
   });
 });
-
-const coveredCallSrcs = harden({
-  makeContract: `${makeContract}`,
-});
-
-export { coveredCallSrcs };

--- a/core/zoe/contracts/publicAuction.js
+++ b/core/zoe/contracts/publicAuction.js
@@ -132,9 +132,3 @@ export const makeContract = harden((zoe, terms) => {
     assays: terms.assays,
   });
 });
-
-const publicAuctionSrcs = harden({
-  makeContract: `${makeContract}`,
-});
-
-export { publicAuctionSrcs };

--- a/core/zoe/contracts/publicSwap.js
+++ b/core/zoe/contracts/publicSwap.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import { sameStructure } from '../../../util/sameStructure';
 
-const makeContract = harden((zoe, terms) => {
+export const makeContract = harden((zoe, terms) => {
   let firstOfferId;
 
   const isMatchingOfferDesc = (extentOps, leftOffer, rightOffer) => {
@@ -81,9 +81,3 @@ const makeContract = harden((zoe, terms) => {
     assays: terms.assays,
   });
 });
-
-const publicSwapSrcs = harden({
-  makeContract: `${makeContract}`,
-});
-
-export { publicSwapSrcs };

--- a/core/zoe/contracts/simpleExchange.js
+++ b/core/zoe/contracts/simpleExchange.js
@@ -11,7 +11,7 @@ import harden from '@agoric/harden';
 // may be less than expected. This simple exchange does not support
 // partial fills of orders.
 
-const makeContract = harden((zoe, terms) => {
+export const makeContract = harden((zoe, terms) => {
   const sellOfferIds = [];
   const buyOfferIds = [];
 
@@ -110,9 +110,3 @@ const makeContract = harden((zoe, terms) => {
     assays: terms.assays,
   });
 });
-
-const simpleExchangeSrcs = harden({
-  makeContract: `${makeContract}`,
-});
-
-export { simpleExchangeSrcs };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,37 @@
       "resolved": "https://registry.npmjs.org/@agoric/babel-parser/-/babel-parser-7.6.2.tgz",
       "integrity": "sha512-2yhcfAeGiRLv0OmstYa2hUDPWKE7THCwEjZXi3WeNAz2B6ExeAVkBFDVxbmK3DDR2o47Gwcbj/8oABcH+Q0P0Q=="
     },
+    "@agoric/bundle-source": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@agoric/bundle-source/-/bundle-source-0.1.0.tgz",
+      "integrity": "sha512-v0VZBZEHNiS4m22oAD2uuV4ZjoBvQ4N5Fu9G2P337urpZrxAObfcS/W/XqAC0D14kLT9Rx390SDuCUYWiXedGw==",
+      "dev": true,
+      "requires": {
+        "@agoric/acorn-eventual-send": "^1.0.1",
+        "esm": "^3.2.5",
+        "rollup": "^1.25.1",
+        "rollup-plugin-node-resolve": "^5.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        },
+        "rollup": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.25.1.tgz",
+          "integrity": "sha512-K8ytdEzMa6anHSnfTIs2BLB+NXlQ4qmWwdNHBpYQNWCbZAzj+DRVk7+ssbLSgddwpFW1nThr2GElR+jASF2NPA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        }
+      }
+    },
     "@agoric/default-evaluate-options": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@agoric/default-evaluate-options/-/default-evaluate-options-0.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ses": "^0.6.4"
   },
   "devDependencies": {
+    "@agoric/bundle-source": "^0.1.0",
     "@agoric/swingset-vat": "^0.1.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/test/swingsetTests/zoe/bootstrap.js
+++ b/test/swingsetTests/zoe/bootstrap.js
@@ -1,11 +1,12 @@
 import harden from '@agoric/harden';
 
 import { makeMint } from '../../../core/mint';
-import { automaticRefundSrcs } from '../../../core/zoe/contracts/automaticRefund';
-import { coveredCallSrcs } from '../../../core/zoe/contracts/coveredCall';
-import { publicAuctionSrcs } from '../../../core/zoe/contracts/publicAuction';
-import { publicSwapSrcs } from '../../../core/zoe/contracts/publicSwap';
-import { simpleExchangeSrcs } from '../../../core/zoe/contracts/simpleExchange';
+
+import automaticRefundBundle from './bundle-automaticRefund';
+import coveredCallBundle from './bundle-coveredCall';
+import publicAuctionBundle from './bundle-publicAuction';
+import publicSwapBundle from './bundle-publicSwap';
+import simpleExchangeBundle from './bundle-simpleExchange';
 // TODO: test autoswap
 
 const setupBasicMints = () => {
@@ -104,11 +105,26 @@ function build(E, log) {
       const zoe = await E(vats.zoe).getZoe();
 
       const installations = {
-        automaticRefund: await E(zoe).install(automaticRefundSrcs),
-        coveredCall: await E(zoe).install(coveredCallSrcs),
-        publicAuction: await E(zoe).install(publicAuctionSrcs),
-        publicSwap: await E(zoe).install(publicSwapSrcs),
-        simpleExchange: await E(zoe).install(simpleExchangeSrcs),
+        automaticRefund: await E(zoe).install(
+          automaticRefundBundle.source,
+          automaticRefundBundle.moduleFormat,
+        ),
+        coveredCall: await E(zoe).install(
+          coveredCallBundle.source,
+          coveredCallBundle.moduleFormat,
+        ),
+        publicAuction: await E(zoe).install(
+          publicAuctionBundle.source,
+          publicAuctionBundle.moduleFormat,
+        ),
+        publicSwap: await E(zoe).install(
+          publicSwapBundle.source,
+          publicSwapBundle.moduleFormat,
+        ),
+        simpleExchange: await E(zoe).install(
+          simpleExchangeBundle.source,
+          simpleExchangeBundle.moduleFormat,
+        ),
       };
 
       const [testName, installation, startingExtents] = argv;

--- a/test/swingsetTests/zoe/vat-zoe.js
+++ b/test/swingsetTests/zoe/vat-zoe.js
@@ -3,7 +3,7 @@ import harden from '@agoric/harden';
 import { makeZoe } from '../../../core/zoe/zoe/zoe';
 
 const build = (_E, _log) => {
-  const zoe = makeZoe();
+  const zoe = makeZoe({ require });
   return harden({
     getZoe: () => zoe,
   });

--- a/test/unitTests/core/zoe/contracts/test-automaticRefund.js
+++ b/test/unitTests/core/zoe/contracts/test-automaticRefund.js
@@ -1,15 +1,18 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
+
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
-import { automaticRefundSrcs } from '../../../../../core/zoe/contracts/automaticRefund';
+
+const automaticRefundRoot = `${__dirname}/../../../../../core/zoe/contracts/automaticRefund`;
 
 test('zoe.makeInstance with automaticRefund', async t => {
   try {
     // Setup zoe and mints
     const { assays: defaultAssays, mints } = setup();
     const assays = defaultAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
 
     // Setup Alice
@@ -22,8 +25,11 @@ test('zoe.makeInstance with automaticRefund', async t => {
     const bobSimoleanPurse = mints[1].mint(assays[1].makeAssetDesc(17));
     const bobSimoleanPayment = bobSimoleanPurse.withdrawAll();
 
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+
     // 1: Alice creates an automatic refund instance
-    const installationId = zoe.install(automaticRefundSrcs);
+    const installationId = zoe.install(source, moduleFormat);
     const terms = harden({
       assays,
     });
@@ -177,7 +183,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     // Setup zoe and mints
     const { assays: originalAssays, mints } = setup();
     const assays = originalAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(30));
@@ -190,7 +196,10 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     ]);
 
     // 1: Alice creates 3 automatic refund instances
-    const installationId = zoe.install(automaticRefundSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
     const terms = harden({
       assays,
     });
@@ -282,7 +291,7 @@ test('zoe - alice cancels before entering a contract', async t => {
     // Setup zoe and mints
     const { assays: defaultAssays, mints } = setup();
     const assays = defaultAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -317,7 +326,9 @@ test('zoe - alice cancels before entering a contract', async t => {
 
     const alicePayoff = await payoffP;
 
-    const installationId = zoe.install(automaticRefundSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+    const installationId = zoe.install(source, moduleFormat);
     const terms = harden({
       assays,
     });
@@ -361,7 +372,7 @@ test('zoe - alice cancels after completion', async t => {
     // Setup zoe and mints
     const { assays: defaultAssays, mints } = setup();
     const assays = defaultAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -392,7 +403,9 @@ test('zoe - alice cancels after completion', async t => {
       payoff: payoffP,
     } = await zoe.escrow(aliceConditions, alicePayments);
 
-    const installationId = zoe.install(automaticRefundSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+    const installationId = zoe.install(source, moduleFormat);
     const terms = harden({
       assays,
     });

--- a/test/unitTests/core/zoe/contracts/test-autoswap.js
+++ b/test/unitTests/core/zoe/contracts/test-autoswap.js
@@ -1,14 +1,16 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
-import { autoswapSrcs } from '../../../../../core/zoe/contracts/autoswap';
+
+const autoswapRoot = `${__dirname}/../../../../../core/zoe/contracts/autoswap`;
 
 test('autoSwap with valid offers', async t => {
   try {
     const { assays: defaultAssays, mints } = setup();
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const assays = defaultAssays.slice(0, 2);
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
 
@@ -29,7 +31,10 @@ test('autoSwap with valid offers', async t => {
 
     // 1: Alice creates an autoswap instance
 
-    const installationId = zoe.install(autoswapSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(autoswapRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
     const terms = {
       assays,
     };

--- a/test/unitTests/core/zoe/contracts/test-coveredCall.js
+++ b/test/unitTests/core/zoe/contracts/test-coveredCall.js
@@ -1,21 +1,26 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
 import buildManualTimer from '../../../../../tools/manualTimer';
 import { sameStructure } from '../../../../../util/sameStructure';
-import { coveredCallSrcs } from '../../../../../core/zoe/contracts/coveredCall';
-import { publicSwapSrcs } from '../../../../../core/zoe/contracts/publicSwap';
+
+const coveredCallRoot = `${__dirname}/../../../../../core/zoe/contracts/coveredCall`;
+const publicSwapRoot = `${__dirname}/../../../../../core/zoe/contracts/publicSwap`;
 
 test('zoe - coveredCall', async t => {
   try {
     const { mints: defaultMints, assays: defaultAssays } = setup();
     const mints = defaultMints.slice(0, 2);
     const assays = defaultAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
-    const coveredCallInstallationId = zoe.install(coveredCallSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(coveredCallRoot);
+
+    const coveredCallInstallationId = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -199,9 +204,12 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     const { mints: defaultMints, assays: defaultAssays } = setup();
     const mints = defaultMints.slice(0, 2);
     const assays = defaultAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
-    const coveredCallInstallationId = zoe.install(coveredCallSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(coveredCallRoot);
+
+    const coveredCallInstallationId = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -391,9 +399,17 @@ test('zoe - coveredCall with swap for invite', async t => {
     const [moolaMint, simoleanMint, bucksMint] = mints;
     const [moolaAssay, simoleanAssay, bucksAssay] = assays;
     const timer = buildManualTimer(console.log);
-    const zoe = await makeZoe();
-    const coveredCallInstallationId = zoe.install(coveredCallSrcs);
-    const swapInstallationId = zoe.install(publicSwapSrcs);
+    const zoe = await makeZoe({ require });
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(coveredCallRoot);
+
+    const coveredCallInstallationId = zoe.install(source, moduleFormat);
+    const {
+      source: swapSource,
+      moduleFormat: swapModuleFormat,
+    } = await bundleSource(publicSwapRoot);
+
+    const swapInstallationId = zoe.install(swapSource, swapModuleFormat);
 
     // Setup Alice
     // Alice starts with 3 moola
@@ -765,8 +781,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const [moolaMint, simoleanMint, bucksMint] = mints;
     const [moolaAssay, simoleanAssay, bucksAssay] = assays;
     const timer = buildManualTimer(console.log);
-    const zoe = await makeZoe();
-    const coveredCallInstallationId = zoe.install(coveredCallSrcs);
+    const zoe = await makeZoe({ require });
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(coveredCallRoot);
+
+    const coveredCallInstallationId = zoe.install(source, moduleFormat);
 
     // Setup Alice
     // Alice starts with 3 moola

--- a/test/unitTests/core/zoe/contracts/test-publicAuction.js
+++ b/test/unitTests/core/zoe/contracts/test-publicAuction.js
@@ -1,16 +1,17 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
 
-import { publicAuctionSrcs } from '../../../../../core/zoe/contracts/publicAuction';
+const publicAuctionRoot = `${__dirname}/../../../../../core/zoe/contracts/publicAuction`;
 
 test('zoe - secondPriceAuction w/ 3 bids', async t => {
   try {
     const { assays: originalAssays, mints, descOps } = setup();
     const assays = originalAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
 
     // Setup Alice
@@ -35,7 +36,10 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
     // 1: Alice creates a secondPriceAuction instance
 
-    const installationId = zoe.install(publicAuctionSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(publicAuctionRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
     const numBidsAllowed = 3;
     const { instance: aliceAuction, instanceId } = await zoe.makeInstance(
       installationId,
@@ -289,7 +293,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
   try {
     const { assays: originalAssays, mints, descOps } = setup();
     const assays = originalAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
 
     // Setup Alice
@@ -314,7 +318,10 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
 
     // 1: Alice creates a secondPriceAuction instance
 
-    const installationId = zoe.install(publicAuctionSrcs);
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(publicAuctionRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
     const numBidsAllowed = 3;
     const { instance: aliceAuction, instanceId } = await zoe.makeInstance(
       installationId,

--- a/test/unitTests/core/zoe/contracts/test-publicSwap.js
+++ b/test/unitTests/core/zoe/contracts/test-publicSwap.js
@@ -1,18 +1,23 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
 
-import { publicSwapSrcs } from '../../../../../core/zoe/contracts/publicSwap';
+const publicSwapRoot = `${__dirname}/../../../../../core/zoe/contracts/publicSwap`;
 
 test('zoe - publicSwap', async t => {
   try {
     const { assays: originalAssays, mints } = setup();
     const assays = originalAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
     const payoffAssay = zoe.getPayoffAssay();
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(publicSwapRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -28,7 +33,7 @@ test('zoe - publicSwap', async t => {
     const carolSimoleanPurse = mints[1].mint(assays[1].makeAssetDesc(0));
 
     // 1: Alice creates a publicSwap instance
-    const installationId = zoe.install(publicSwapSrcs);
+
     const { instance: aliceSwap, instanceId } = await zoe.makeInstance(
       installationId,
       { assays },

--- a/test/unitTests/core/zoe/contracts/test-simpleExchange.js
+++ b/test/unitTests/core/zoe/contracts/test-simpleExchange.js
@@ -1,17 +1,22 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
+import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '../../../../../core/zoe/zoe/zoe';
 import { setup } from '../setupBasicMints';
 
-import { simpleExchangeSrcs } from '../../../../../core/zoe/contracts/simpleExchange';
+const simpleExchangeRoot = `${__dirname}/../../../../../core/zoe/contracts/simpleExchange`;
 
 test('zoe - simpleExchange', async t => {
   try {
     const { assays: originalAssays, mints, descOps } = setup();
     const assays = originalAssays.slice(0, 2);
-    const zoe = await makeZoe();
+    const zoe = await makeZoe({ require });
     const escrowReceiptAssay = zoe.getEscrowReceiptAssay();
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(simpleExchangeRoot);
+
+    const installationId = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -24,7 +29,6 @@ test('zoe - simpleExchange', async t => {
     const bobSimoleanPayment = bobSimoleanPurse.withdrawAll();
 
     // 1: Alice creates a simpleExchange instance
-    const installationId = zoe.install(simpleExchangeSrcs);
     const { instance: aliceExchange, instanceId } = await zoe.makeInstance(
       installationId,
       { assays },


### PR DESCRIPTION
Makes the Zoe contracts compatible with how we are using rollup to bundle files. This gives us the ability to split up a governing contract into separate files and to reuse components between files. 

This PR also changes the Zoe unit tests and SwingSet tests to use the bundler.

@michaelfig I used [your example PR](https://github.com/Agoric/ERTP/pull/176) heavily. Let me know if you want any changes.