### PR TITLE
Remove payout payment.

### DIFF
--- a/core/zoe/zoe/state.js
+++ b/core/zoe/zoe/state.js
@@ -144,9 +144,6 @@ const makeState = () => {
       offerHandleToResult.init(offerHandle, result);
       activeOffers.add(offerHandle);
     },
-    replaceResult: (offerHandle, newResult) => {
-      offerHandleToResult.set(offerHandle, newResult);
-    },
     recordUsedInInstance: (instanceHandle, offerHandle) =>
       offerHandleToInstanceHandle.init(offerHandle, instanceHandle),
     getInstanceHandleForOfferHandle: offerHandle => {

--- a/core/zoe/zoe/zoe.js
+++ b/core/zoe/zoe/zoe.js
@@ -12,7 +12,6 @@ import {
   escrowEmptyOffer,
   escrowOffer,
   mintEscrowReceiptPayment,
-  mintPayoutPayment,
   completeOffers,
   makeAssetDesc,
   makeEmptyExtents,
@@ -36,12 +35,6 @@ const makeZoe = async (additionalEndowments = {}) => {
     seatAssay: inviteAssay,
     addUseObj: inviteAddUseObj,
   } = makeSeatMint('zoeInvite');
-
-  const {
-    seatMint: payoutMint,
-    seatAssay: payoutAssay,
-    addUseObj: payoutAddUseObj,
-  } = makeSeatMint('zoePayout');
 
   const escrowReceiptMint = makeMint(
     'zoeEscrowReceipts',
@@ -248,7 +241,6 @@ const makeZoe = async (additionalEndowments = {}) => {
   const zoeService = harden({
     getEscrowReceiptAssay: () => escrowReceiptAssay,
     getInviteAssay: () => inviteAssay,
-    getPayoutAssay: () => payoutAssay,
     getAssaysForInstance: instanceHandle =>
       readOnlyState.getAssays(instanceHandle),
     install: bundle => {
@@ -334,27 +326,6 @@ const makeZoe = async (additionalEndowments = {}) => {
       const escrowResult = {
         escrowReceipt: escrowReceiptPaymentP,
         payout: result.p,
-        makePayoutPaymentObj: harden({
-          makePayoutPayment: () => {
-            // if offer has already completed, we cannot make a payment
-            const { active } = readOnlyState.getStatusFor(
-              harden([offerHandle]),
-            );
-            if (active.length !== 1) {
-              throw new Error('offer has already completed');
-            }
-            result.res([]);
-            const newResult = makePromise();
-            adminState.replaceResult(offerHandle, newResult);
-            return mintPayoutPayment(
-              payoutMint,
-              payoutAddUseObj,
-              offerRules,
-              newResult,
-              adminState.getInstanceHandleForOfferHandle(offerHandle),
-            );
-          },
-        }),
       };
       const { exitRule = { kind: 'onDemand' } } = offerRules;
       if (exitRule.kind === 'afterDeadline') {

--- a/core/zoe/zoe/zoeUtils.js
+++ b/core/zoe/zoe/zoeUtils.js
@@ -7,25 +7,6 @@ import { insist } from '../../../util/insist';
 // These utilities are used within Zoe itself. Importantly, there is
 // no ambient authority for these utilities. Any authority must be
 // passed in, making it easy to see which functions can affect what.
-const mintPayoutPayment = (
-  seatMint,
-  addUseObj,
-  offerRules,
-  result,
-  instanceHandle,
-) => {
-  const payoutExtent = harden({
-    offerHandle: harden({}),
-    offerRules,
-    instanceHandle,
-  });
-  const payoutPurseP = seatMint.mint(payoutExtent);
-  const seat = harden({
-    getPayout: () => result.p,
-  });
-  addUseObj(payoutExtent.offerHandle, seat);
-  return payoutPurseP.withdrawAll();
-};
 
 const mintEscrowReceiptPayment = (
   escrowReceiptMint,
@@ -205,7 +186,6 @@ export {
   escrowEmptyOffer,
   escrowOffer,
   mintEscrowReceiptPayment,
-  mintPayoutPayment,
   completeOffers,
   makeEmptyExtents,
   makeAssetDesc,

--- a/test/swingsetTests/zoe/test-zoe.js
+++ b/test/swingsetTests/zoe/test-zoe.js
@@ -176,16 +176,14 @@ const expectedPublicSwapOkLog = [
   '=> alice, bob, carol and dave are set up',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
-  'bobMoolaPurse: balance {"label":{"assay":{},"allegedName":"moola"},"extent":3}',
-  'bobSimoleanPurse;: balance {"label":{"assay":{},"allegedName":"simoleans"},"extent":0}',
-  'carolMoolaPurse: balance {"label":{"assay":{},"allegedName":"moola"},"extent":0}',
-  'carolSimoleanPurse;: balance {"label":{"assay":{},"allegedName":"simoleans"},"extent":7}',
   'aliceMoolaPurse: balance {"label":{"assay":{},"allegedName":"moola"},"extent":0}',
-  'aliceSimoleanPurse;: balance {"label":{"assay":{},"allegedName":"simoleans"},"extent":0}',
+  'bobMoolaPurse: balance {"label":{"assay":{},"allegedName":"moola"},"extent":3}',
+  'aliceSimoleanPurse;: balance {"label":{"assay":{},"allegedName":"simoleans"},"extent":7}',
+  'bobSimoleanPurse;: balance {"label":{"assay":{},"allegedName":"simoleans"},"extent":0}',
 ];
 test('zoe - publicSwap - valid inputs - with SES', async t => {
   try {
-    const startingExtents = [[3, 0], [0, 7], [0, 0]];
+    const startingExtents = [[3, 0], [0, 7]];
     const dump = await main(true, 'zoe', [
       'publicSwapOk',
       'publicSwap',

--- a/test/swingsetTests/zoe/vat-carol.js
+++ b/test/swingsetTests/zoe/vat-carol.js
@@ -60,52 +60,6 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       await showPaymentBalance(moolaPurseP, 'carolMoolaPurse');
       await showPaymentBalance(simoleanPurseP, 'carolSimoleanPurse;');
     },
-    doPublicSwap: async (instanceHandle, payoutPaymentP) => {
-      const moolaAssay = await E(moolaPurseP).getAssay();
-      const simoleanAssay = await E(simoleanPurseP).getAssay();
-
-      const assays = harden([moolaAssay, simoleanAssay]);
-
-      const payoutAssay = await E(zoe).getPayoutAssay();
-
-      const offerRules = harden({
-        payoutRules: [
-          {
-            kind: 'offerExactly',
-            assetDesc: await E(assays[0]).makeAssetDesc(3),
-          },
-          {
-            kind: 'wantExactly',
-            assetDesc: await E(assays[1]).makeAssetDesc(7),
-          },
-        ],
-        exitRule: {
-          kind: 'onDemand',
-        },
-      });
-
-      const carolPayoutPaymentP = await E(payoutAssay).claimAll(payoutPaymentP);
-      const { extent } = await E(carolPayoutPaymentP).getBalance();
-      insist(extent.instanceHandle === instanceHandle)`same instance`;
-      insist(sameStructure(extent.offerRules, offerRules))`same offerRules`;
-      const carolPayoutObj = await E(carolPayoutPaymentP).unwrap();
-      const payoutP = await E(carolPayoutObj).getPayout();
-
-      const { installationHandle, terms } = await E(zoe).getInstance(
-        instanceHandle,
-      );
-
-      insist(installationHandle === installId)`wrong installation`;
-      insist(sameStructure(assays, terms.assays))`assays were not as expected`;
-
-      const carolResult = await payoutP;
-
-      await E(moolaPurseP).depositAll(carolResult[0]);
-      await E(simoleanPurseP).depositAll(carolResult[1]);
-
-      await showPaymentBalance(moolaPurseP, 'carolMoolaPurse');
-      await showPaymentBalance(simoleanPurseP, 'carolSimoleanPurse;');
-    },
   });
 };
 

--- a/test/unitTests/core/zoe/contracts/test-automaticRefund.js
+++ b/test/unitTests/core/zoe/contracts/test-automaticRefund.js
@@ -116,7 +116,6 @@ test('zoe with automaticRefund', async t => {
     const {
       escrowReceipt: allegedAliceEscrowReceipt,
       payout: alicePayoutP,
-      makePayoutPaymentObj,
     } = await zoe.escrow(aliceOfferRules, alicePayments);
 
     // 3: Alice does a claimAll on the escrowReceipt payment. (This is
@@ -189,10 +188,6 @@ test('zoe with automaticRefund', async t => {
     t.equals(bobOutcome, 'The offer was accepted');
 
     const alicePayout = await alicePayoutP;
-    t.throws(
-      () => makePayoutPaymentObj.makePayoutPayment(),
-      /offer has already completed/,
-    );
     const bobPayout = await bobPayoutP;
 
     // Alice got back what she put in


### PR DESCRIPTION
This removes the ability to create an ERTP payment for the payout. The original motivation was to be able to transfer the rights to the payout, but let's push this to a later version so that the current version is easier to explain and analyze. 