### PR TITLE
More simplifications and clean up

### DIFF
--- a/core/config/seatConfig.js
+++ b/core/config/seatConfig.js
@@ -6,12 +6,13 @@ import { insist } from '../../util/insist';
 
 const insistSeat = seat => {
   const properties = Object.getOwnPropertyNames(seat);
-  insist(properties.includes('offerHandle'))`must include 'offerHandle'`;
+  // The `handle` is how the use object will be looked up
+  insist(properties.includes('handle'))`must include 'handle'`;
   insist(
-    passStyleOf(seat.offerHandle) === 'presence' &&
-      Object.entries(seat.offerHandle).length === 0 &&
-      seat.offerHandle.constructor === Object,
-  )`offerHandle should be an empty object`;
+    passStyleOf(seat.handle) === 'presence' &&
+      Object.entries(seat.handle).length === 0 &&
+      seat.handle.constructor === Object,
+  )`handle should be an empty object`;
   insist(passStyleOf(seat) === 'copyRecord')`seat should be a record`;
   return seat;
 };

--- a/core/seatMint.js
+++ b/core/seatMint.js
@@ -9,14 +9,14 @@ import { makeMint } from './mint';
  * unforgeable empty objects) to use objects
  */
 const makeSeatMint = (description = 'seats') => {
-  const offerHandleToSeat = new WeakMap();
+  const handleToSeat = new WeakMap();
 
   const addUseObj = (handle, useObj) => {
-    offerHandleToSeat.set(handle, useObj);
+    handleToSeat.set(handle, useObj);
   };
 
   const makeUseObj = seatExtent => {
-    return harden(offerHandleToSeat.get(seatExtent.offerHandle));
+    return harden(handleToSeat.get(seatExtent.handle));
   };
 
   const paymentMakeUseAndBurn = async (assay, payment) => {

--- a/core/zoe/contracts/autoswap.js
+++ b/core/zoe/contracts/autoswap.js
@@ -2,7 +2,11 @@ import harden from '@agoric/harden';
 import { natSafeMath } from './helpers/safeMath';
 import { rejectOffer } from './helpers/userFlow';
 import { vectorWith, vectorWithout } from './helpers/extents';
-import { hasValidPayoutRules } from './helpers/payoutRules';
+import {
+  hasValidPayoutRules,
+  makeAssetDesc,
+  makeOfferRules,
+} from './helpers/offerRules';
 
 import { makeMint } from '../../mint';
 
@@ -88,7 +92,8 @@ export const makeContract = harden((zoe, terms) => {
     const exitRule = {
       kind: 'noExit',
     };
-    const liquidityOfferRules = zoe.makeOfferRules(
+    const liquidityOfferRules = makeOfferRules(
+      zoe,
       liquidityOfferKinds,
       extents,
       exitRule,
@@ -192,14 +197,6 @@ export const makeContract = harden((zoe, terms) => {
       newTokenInPoolE: add(newTokenInPoolE, feeTokenInE),
       newTokenOutPoolE,
     };
-  };
-
-  const makeAssetDesc = (extentOps, label, allegedExtent) => {
-    extentOps.insistKind(allegedExtent);
-    return harden({
-      label,
-      extent: allegedExtent,
-    });
   };
 
   const assetDescsToExtentsArray = (extentOps, assetDescs) =>

--- a/core/zoe/contracts/coveredCall.js
+++ b/core/zoe/contracts/coveredCall.js
@@ -5,7 +5,7 @@ import {
   isExactlyMatchingPayoutRules,
   makeExactlyMatchingPayoutRules,
   hasValidPayoutRules,
-} from './helpers/payoutRules';
+} from './helpers/offerRules';
 
 export const makeContract = harden((zoe, terms) => {
   let firstOfferHandle;

--- a/core/zoe/contracts/helpers/offerRules.js
+++ b/core/zoe/contracts/helpers/offerRules.js
@@ -69,3 +69,44 @@ export const getActivePayoutRules = (zoe, offerHandles) => {
     payoutRulesArray: zoe.getPayoutRulesFor(active),
   });
 };
+
+/**
+ * Make an assetDesc without access to the assay, which we don't want
+ * to use because it may be remote.
+ * @param {object} extentOps - the extent ops for the assay
+ * @param {object} label - the label for the assay to use in the assetDesc
+ * @param {*} allegedExtent - the extent to use in the assetDesc
+ */
+export const makeAssetDesc = (extentOps, label, allegedExtent) => {
+  extentOps.insistKind(allegedExtent);
+  return harden({
+    label,
+    extent: allegedExtent,
+  });
+};
+
+/**
+ * A helper to make offerRules without having to write out the rules
+ * manually, and without using an assay (which we don't want to use
+ * because it may be remote).
+ * @param {object} zoe - the contract facet of Zoe
+ * @param  {array} kinds - an array of payoutRule kinds, in the order
+ * of the intended payoutRules
+ * @param  {array} extents - an array of extents, in the order of the
+ * intended payoutRules
+ * @param  {object} exitRule - an exitRule
+ */
+export const makeOfferRules = (zoe, kinds, extents, exitRule) => {
+  const extentOpsArray = zoe.getExtentOpsArray();
+  const labels = zoe.getLabels();
+  const payoutRules = extentOpsArray.map((extentOps, i) =>
+    harden({
+      kind: kinds[i],
+      assetDesc: makeAssetDesc(extentOps, labels[i], extents[i]),
+    }),
+  );
+  return harden({
+    payoutRules,
+    exitRule,
+  });
+};

--- a/core/zoe/contracts/publicAuction.js
+++ b/core/zoe/contracts/publicAuction.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 
 import { rejectOffer, defaultAcceptanceMsg } from './helpers/userFlow';
-import { hasValidPayoutRules } from './helpers/payoutRules';
+import { hasValidPayoutRules } from './helpers/offerRules';
 import {
   isOverMinimumBid,
   secondPriceLogic,

--- a/core/zoe/contracts/publicSwap.js
+++ b/core/zoe/contracts/publicSwap.js
@@ -4,7 +4,7 @@ import { rejectOffer, defaultAcceptanceMsg } from './helpers/userFlow';
 import {
   isExactlyMatchingPayoutRules,
   hasValidPayoutRules,
-} from './helpers/payoutRules';
+} from './helpers/offerRules';
 
 export const makeContract = harden((zoe, terms) => {
   let firstOfferHandle;

--- a/core/zoe/contracts/simpleExchange.js
+++ b/core/zoe/contracts/simpleExchange.js
@@ -4,7 +4,7 @@ import { rejectOffer, defaultAcceptanceMsg } from './helpers/userFlow';
 import {
   hasValidPayoutRules,
   getActivePayoutRules,
-} from './helpers/payoutRules';
+} from './helpers/offerRules';
 import {
   isMatchingLimitOrder,
   reallocateSurplusToSeller as reallocate,

--- a/core/zoe/zoe/zoeUtils.js
+++ b/core/zoe/zoe/zoeUtils.js
@@ -188,6 +188,5 @@ export {
   mintEscrowReceiptPayment,
   completeOffers,
   makeEmptyExtents,
-  makeAssetDesc,
   toAssetDescMatrix,
 };

--- a/test/swingsetTests/zoe/vat-bob.js
+++ b/test/swingsetTests/zoe/vat-bob.js
@@ -109,7 +109,10 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       // Bob checks that the invite is for the right covered call
       const { extent: inviteExtent } = await E(invite).getBalance();
       insist(inviteExtent.instanceHandle === instanceHandle)`wrong instance`;
-      insist(inviteExtent.installationHandle === installId)`wrong installation`;
+
+      const instanceInfo = await E(zoe).getInstance(instanceHandle);
+
+      insist(instanceInfo.installationHandle === installId)`wrong installation`;
       insist(
         sameStructure(
           inviteExtent.offerToBeMade,

--- a/test/unitTests/core/test-seat.js
+++ b/test/unitTests/core/test-seat.js
@@ -6,7 +6,7 @@ import { setup } from './zoe/setupBasicMints';
 import { insist } from '../../../util/insist';
 
 /*
- * A seat extent must have an offerHandle but otherwise can have arbitrary
+ * A seat extent must have a handle but otherwise can have arbitrary
  * properties as long as the extent is a copyRecord
  */
 
@@ -36,7 +36,7 @@ test('seatMint', async t => {
     };
 
     const purse1Extent = harden({
-      offerHandle: harden({}),
+      handle: harden({}),
       offerToBeMade: {
         payoutRules: [
           { kind: 'offerExactly', assetDesc: assays[0].makeAssetDesc(8) },
@@ -47,7 +47,7 @@ test('seatMint', async t => {
 
     const purse1 = seatMint.mint(purse1Extent);
     t.deepEqual(purse1.getBalance().extent, purse1Extent);
-    addUseObj(purse1Extent.offerHandle, makeUseObj(purse1Extent));
+    addUseObj(purse1Extent.handle, makeUseObj(purse1Extent));
 
     const useObjPurse1 = await purse1.unwrap();
     // purse1 should be empty at this point. Note that `withdrawAll` doesn't
@@ -62,7 +62,7 @@ test('seatMint', async t => {
     );
 
     const purse2Extent = harden({
-      offerHandle: harden({}),
+      handle: harden({}),
       offerMade: {
         payoutRules: [
           { kind: 'offerExactly', assetDesc: assays[0].makeAssetDesc(8) },
@@ -73,7 +73,7 @@ test('seatMint', async t => {
 
     const purse2 = seatMint.mint(purse2Extent);
     t.deepEqual(purse2.getBalance().extent, purse2Extent);
-    addUseObj(purse2Extent.offerHandle, makeUseObj(purse2Extent));
+    addUseObj(purse2Extent.handle, makeUseObj(purse2Extent));
 
     const useObjPurse2 = await purse2.unwrap();
     // purse1 should be empty at this point. Note that `withdrawAll` doesn't

--- a/test/unitTests/core/zoe/contracts/helpers/test-offerRules.js
+++ b/test/unitTests/core/zoe/contracts/helpers/test-offerRules.js
@@ -1,0 +1,18 @@
+import { test } from 'tape-promise/tape';
+
+import { makeAssetDesc } from '../../../../../../core/zoe/contracts/helpers/offerRules';
+import { setup } from '../../setupBasicMints';
+
+test('makeAssetDesc', t => {
+  try {
+    const { extentOps, labels, assays, mints } = setup();
+    const assetDesc = makeAssetDesc(extentOps[0], labels[0], 10);
+    t.deepEquals(assetDesc, assays[0].makeAssetDesc(10));
+    const purse = mints[0].mint(assetDesc);
+    t.deepEquals(purse.getBalance(), assetDesc);
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});

--- a/test/unitTests/core/zoe/contracts/test-coveredCall.js
+++ b/test/unitTests/core/zoe/contracts/test-coveredCall.js
@@ -20,7 +20,7 @@ test('zoe - coveredCall', async t => {
     // Pack the contract.
     const { source, moduleFormat } = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationId = zoe.install(source, moduleFormat);
+    const coveredCallInstallationHandle = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -40,7 +40,7 @@ test('zoe - coveredCall', async t => {
       instance: aliceCoveredCall,
       instanceHandle,
       terms: aliceTerms,
-    } = await zoe.makeInstance(coveredCallInstallationId, terms);
+    } = await zoe.makeInstance(coveredCallInstallationHandle, terms);
 
     // The assays are defined at this step
     t.deepEquals(aliceTerms.assays, assays);
@@ -124,7 +124,6 @@ test('zoe - coveredCall', async t => {
 
     const inviteExtent = bobInvitePayment.getBalance().extent;
     t.equal(inviteExtent.instanceHandle, instanceHandle);
-    t.equal(inviteExtent.installationHandle, coveredCallInstallationId);
     t.ok(sameStructure(inviteExtent.offerMadeRules, aliceOfferRules));
     t.ok(
       sameStructure(
@@ -211,7 +210,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     // Pack the contract.
     const { source, moduleFormat } = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationId = zoe.install(source, moduleFormat);
+    const coveredCallInstallationHandle = zoe.install(source, moduleFormat);
 
     // Setup Alice
     const aliceMoolaPurse = mints[0].mint(assays[0].makeAssetDesc(3));
@@ -232,7 +231,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
       instance: aliceCoveredCall,
       instanceHandle,
       terms: aliceTerms,
-    } = await zoe.makeInstance(coveredCallInstallationId, terms);
+    } = await zoe.makeInstance(coveredCallInstallationHandle, terms);
 
     // The assays are defined at this step
     t.deepEquals(aliceTerms.assays, assays);
@@ -321,7 +320,6 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
 
     const inviteExtent = bobInvitePayment.getBalance().extent;
     t.equal(inviteExtent.instanceHandle, instanceHandle);
-    t.equal(inviteExtent.installationHandle, coveredCallInstallationId);
     t.ok(sameStructure(inviteExtent.offerMadeRules, aliceOfferRules));
     t.ok(
       sameStructure(
@@ -407,7 +405,7 @@ test('zoe - coveredCall with swap for invite', async t => {
     // Pack the contract.
     const { source, moduleFormat } = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationId = zoe.install(source, moduleFormat);
+    const coveredCallInstallationHandle = zoe.install(source, moduleFormat);
     const {
       source: swapSource,
       moduleFormat: swapModuleFormat,
@@ -444,7 +442,7 @@ test('zoe - coveredCall with swap for invite', async t => {
     const {
       instance: aliceCoveredCall,
       instanceHandle,
-    } = await zoe.makeInstance(coveredCallInstallationId, terms);
+    } = await zoe.makeInstance(coveredCallInstallationHandle, terms);
 
     // 2: Alice escrows with Zoe. She specifies her offer offerRules,
     // which include an offer description as well as the exit
@@ -506,16 +504,21 @@ test('zoe - coveredCall with swap for invite', async t => {
 
     const inviteExtent = bobInvitePayment.getBalance().extent;
 
-    // Is the installation as expected?
-    t.equal(inviteExtent.installationHandle, coveredCallInstallationId);
-
     // Does the instanceHandle in the invite match what Alice told him?
     t.equal(inviteExtent.instanceHandle, instanceHandle);
+
+    const {
+      terms: inviteTerms,
+      installationHandle: inviteInstallationHandle,
+    } = zoe.getInstance(instanceHandle);
+
+    // Is the installation as expected?
+    t.equal(inviteInstallationHandle, coveredCallInstallationHandle);
 
     // Are the assays and other terms as expected?
     t.ok(
       sameStructure(
-        inviteExtent.terms,
+        inviteTerms,
         harden({ assays: [moolaAssay, simoleanAssay] }),
       ),
     );
@@ -787,7 +790,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     // Pack the contract.
     const { source, moduleFormat } = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationId = zoe.install(source, moduleFormat);
+    const coveredCallInstallationHandle = zoe.install(source, moduleFormat);
 
     // Setup Alice
     // Alice starts with 3 moola
@@ -818,7 +821,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const {
       instance: aliceCoveredCall,
       instanceHandle,
-    } = await zoe.makeInstance(coveredCallInstallationId, terms);
+    } = await zoe.makeInstance(coveredCallInstallationHandle, terms);
 
     // 2: Alice escrows with Zoe. She specifies her offer offerRules,
     // which include an offer description as well as the exit
@@ -880,16 +883,21 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
 
     const inviteExtent = bobInvitePayment.getBalance().extent;
 
-    // Is the installation as expected?
-    t.equal(inviteExtent.installationHandle, coveredCallInstallationId);
-
     // Does the instanceHandle in the invite match what Alice told him?
     t.equal(inviteExtent.instanceHandle, instanceHandle);
+
+    const {
+      installationHandle: inviteInstallationHandle,
+      terms: inviteTerms,
+    } = zoe.getInstance(instanceHandle);
+
+    // Is the installation as expected?
+    t.equal(inviteInstallationHandle, coveredCallInstallationHandle);
 
     // Are the assays and other terms as expected?
     t.ok(
       sameStructure(
-        inviteExtent.terms,
+        inviteTerms,
         harden({ assays: [moolaAssay, simoleanAssay] }),
       ),
     );
@@ -957,7 +965,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
       instance: bobSecondCoveredCall,
       instanceHandle: secondCoveredCallInstanceHandle,
     } = await zoe.makeInstance(
-      coveredCallInstallationId,
+      coveredCallInstallationHandle,
       harden({
         assays: [inviteAssay, bucksAssay],
       }),
@@ -1012,16 +1020,21 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
 
     const daveInviteExtent = inviteForDave.getBalance().extent;
 
-    // Is the installation as expected?
-    t.equal(daveInviteExtent.installationHandle, coveredCallInstallationId);
-
     // Does the instanceHandle in the invite match what Bob told him?
     t.equal(daveInviteExtent.instanceHandle, secondCoveredCallInstanceHandle);
+
+    const {
+      installationHandle: daveInviteInstallationHandle,
+      terms: daveInviteTerms,
+    } = zoe.getInstance(daveInviteExtent.instanceHandle);
+
+    // Is the installation as expected?
+    t.equal(daveInviteInstallationHandle, coveredCallInstallationHandle);
 
     // Are the assays and other terms as expected?
     t.ok(
       sameStructure(
-        daveInviteExtent.terms,
+        daveInviteTerms,
         harden({ assays: [inviteAssay, bucksAssay] }),
       ),
     );

--- a/test/unitTests/core/zoe/test-zoeUtils.js
+++ b/test/unitTests/core/zoe/test-zoeUtils.js
@@ -3,7 +3,6 @@ import { test } from 'tape-promise/tape';
 import {
   toAssetDescMatrix,
   makeEmptyExtents,
-  makeAssetDesc,
 } from '../../../../core/zoe/zoe/zoeUtils';
 import { setup } from './setupBasicMints';
 
@@ -34,20 +33,6 @@ test('makeEmptyExtents', t => {
   try {
     const { extentOps } = setup();
     t.deepEquals(makeEmptyExtents(extentOps), [0, 0, 0]);
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
-});
-
-test('makeAssetDesc', t => {
-  try {
-    const { extentOps, labels, assays, mints } = setup();
-    const assetDesc = makeAssetDesc(extentOps[0], labels[0], 10);
-    t.deepEquals(assetDesc, assays[0].makeAssetDesc(10));
-    const purse = mints[0].mint(assetDesc);
-    t.deepEquals(purse.getBalance(), assetDesc);
   } catch (e) {
     t.assert(false, e);
   } finally {


### PR DESCRIPTION
* The `id` in the extents of `seatMint` had mistakenly been renamed to `offerHandle`, even though the id/handle was meant to be an unique identifier for the value of the payment, not anything in particular to do with an offer.

* Add more comments and better organization to Zoe

* remove excess info from the invite extents.