### PR TITLE
Fix typos and UnitOps description

### DIFF
--- a/core/mint.chainmail
+++ b/core/mint.chainmail
@@ -136,7 +136,7 @@ interface Purse (Units) {
 }
 
 /**
- * Payments hold verified units of certain rights issued by Mints. Unitss
+ * Payments hold verified units of certain rights issued by Mints. Units
  * from payments can be deposited in purses, but otherwise, the entire units is
  * available when the payment is transferred. A payment's balance can only fall,
  * through the action of depositExactly(), claimExactly() or burnExactly().
@@ -160,9 +160,9 @@ interface Payment (Units) {
  * the behavior of the set operations on extents (think: arithmetic)
  * such as `empty`, `with`, `without`, `includes`, etc. We extract this
  * custom logic into a extentOps. ExtentOps are about extent
- * arithmetic, whereas UnitOps are about Unitss, which are labeled
+ * arithmetic, whereas UnitOps are about Units, which are labeled
  * extents. UnitOps use ExtentOps to do their extent arithmetic,
- * and then label the results, making new Unitss. 
+ * and then label the results, making new Units. 
  */ 
 interface ExtentOps () {
   /** 

--- a/core/mint.js
+++ b/core/mint.js
@@ -179,13 +179,13 @@ allegedName must be truthy: ${allegedName}`;
         unitsArray.length === namesArray.length,
       )`the units and names should have the same length`;
 
-      const paymentMinusUnitss = unitsArray.reduce((soFar, units) => {
+      const paymentMinusUnits = unitsArray.reduce((soFar, units) => {
         units = unitOps.coerce(units);
         return unitOps.without(soFar, units);
       }, paymentKeeper.getUnits(payment));
 
       insist(
-        unitOps.isEmpty(paymentMinusUnitss),
+        unitOps.isEmpty(paymentMinusUnits),
       )`the units of the proposed new payments do not equal the units of the source payment`;
 
       // ///////////////// commit point //////////////////

--- a/core/unitOps.chainmail
+++ b/core/unitOps.chainmail
@@ -2,12 +2,12 @@
  * Units are asset descriptions and take the form of labeled extents. 
  * UnitOps execute the logic of how units are changed when digital 
  * assets are merged, separated, or otherwise manipulated. For
- * instance, a deposit of 2 bucks into a purse that already has 3 bucks
+ * example, a deposit of 2 bucks into a purse that already has 3 bucks
  * gives a new balance of 5 bucks. An empty purse has 0 bucks. UnitOps 
  * relies heavily on ExtentOps, which manipulates the non-labeled
  * portion.
  */
-struct Units (Extent, Label) {
+struct Units (Label, Extent) {
   label :Label;
   extent :Extent;
 }

--- a/core/unitOps.chainmail
+++ b/core/unitOps.chainmail
@@ -1,7 +1,11 @@
 /**
- * Unitss are wrappers on extents that have been validated by an UnitOps, and
- * can be verified as having been issued by the UnitOps. They contain their
- * extent and a Label. The label identifies a particular assay.
+ * Units are asset descriptions and take the form of labeled extents. 
+ * UnitOps execute the logic of how units are changed when digital 
+ * assets are merged, separated, or otherwise manipulated. For
+ * instance, a deposit of 2 bucks into a purse that already has 3 bucks
+ * gives a new balance of 5 bucks. An empty purse has 0 bucks. UnitOps 
+ * relies heavily on ExtentOps, which manipulates the non-labeled
+ * portion.
  */
 struct Units (Extent, Label) {
   label :Label;
@@ -10,11 +14,11 @@ struct Units (Extent, Label) {
 
 /**
  * Extents describe the extent of something that can be owned or shared.
- * The format is determined by its unitOps. Fungible extents are normally
- * represented by natural numbers. Other extents may be represented as
- * strings naming a particular right, or an arbitrary object that sensibly
- * represents the rights at issue. All Unitss made by the same UnitOps have the
- * same label.
+ * Fungible extents are normally represented by natural numbers. Other 
+ * extents may be represented as strings naming a particular right, or 
+ * an arbitrary object that sensibly represents the rights at issue. 
+ * All Units that represent the same "kind" of digital asset
+ * (originating from the same mint) will have the same label.
  *
  * Extent must be Comparable. (This IDL doesn't yet provide a way to specify
  * subtype relationships for structs.)
@@ -23,9 +27,9 @@ struct Extent {
 }
 
 /**
- * Creator and validator of asset Unitss.
+ * Creator and validator of asset Units.
  *
- * Unitss are the canonical description of tradable goods. They are manipulated
+ * Units are the canonical description of tradable goods. They are manipulated
  * by mints, and represent the goods and currency carried by purses and
  * payments. They can be used to represent things like currency, stock, and the
  * abstract right to participate in a particular exchange.

--- a/test/swingsetTests/splitPayments/vat-alice.js
+++ b/test/swingsetTests/splitPayments/vat-alice.js
@@ -8,13 +8,13 @@ function makeAliceMaker(E, log) {
           const oldPayment = await E(myMoneyPurseP).withdrawAll();
           log('oldPayment balance:', await E(oldPayment).getBalance());
           const assay = await E(myMoneyPurseP).getAssay();
-          const goodUnitssArray = [
+          const goodUnitsArray = [
             await E(assay).makeUnits(900),
             await E(assay).makeUnits(100),
           ];
           const splitPayments = await E(assay).split(
             oldPayment,
-            goodUnitssArray,
+            goodUnitsArray,
           );
           log(
             'splitPayment[0] balance: ',

--- a/test/unitTests/core/test-mint.js
+++ b/test/unitTests/core/test-mint.js
@@ -9,8 +9,8 @@ test('split bad units', t => {
     const purse = mint.mint(1000);
     const payment = purse.withdrawAll();
 
-    const badUnitssArray = Array(2).fill(assay.makeUnits(10));
-    t.throws(_ => assay.split(payment, badUnitssArray));
+    const badUnitsArray = Array(2).fill(assay.makeUnits(10));
+    t.throws(_ => assay.split(payment, badUnitsArray));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -25,8 +25,8 @@ test('split good units', t => {
     const purse = mint.mint(100);
     const oldPayment = purse.withdrawAll();
 
-    const goodUnitssArray = Array(10).fill(assay.makeUnits(10));
-    const splitPayments = assay.split(oldPayment, goodUnitssArray);
+    const goodUnitsArray = Array(10).fill(assay.makeUnits(10));
+    const splitPayments = assay.split(oldPayment, goodUnitsArray);
 
     for (const payment of splitPayments) {
       t.deepEqual(payment.getBalance(), assay.makeUnits(10));


### PR DESCRIPTION
I was going through issues and realized #174 was a quick fix. I was especially motivated because there's an embarrassing typo in which replacing "AssetDesc" with "Unit" created "Unitss".  

This PR fixes the typos and the Unit/Unit Ops Description.