### PR TITLE
package.json: roll back .dev0 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/ertp",
-  "version": "0.1.13-dev.0",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/ertp",
-  "version": "0.1.13-dev.0",
+  "version": "0.1.12",
   "description": "Electronic Rights Transfer Protocol (ERTP). A smart contract framework for exchanging electronic rights",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This prepares for a monorepo, where we want packages/ERTP to provide
`0.1.12` (not `0.1.13-dev.0`), to be compatible with e.g.
packages/cosmic-swingset (which will declare a dependency upon `~0.1.12`,
which is not satisfied by `0.1.13-dev.0`).