### PR TITLE
rename corkboard to sharedMap

### DIFF
--- a/more/sharing/sharedMap.js
+++ b/more/sharing/sharedMap.js
@@ -16,7 +16,7 @@ function makeSharedMap(name) {
     },
     addEntry(key, value) {
       if (namedEntries.has(key)) {
-        throw new Error(`Corkboard ${name} already has an entry for ${key}.`);
+        throw new Error(`SharedMap ${name} already has an entry for ${key}.`);
       }
       orderedEntries.push([key, value]);
       namedEntries.set(key, [value, orderedEntries.length]);

--- a/more/sharing/sharedMap.js
+++ b/more/sharing/sharedMap.js
@@ -3,7 +3,7 @@
 import harden from '@agoric/harden';
 
 // Allows multiple parties to store values for retrieval by others.
-function makeCorkboard(name) {
+function makeSharedMap(name) {
   const namedEntries = new Map();
   const orderedEntries = [];
 
@@ -28,6 +28,6 @@ function makeCorkboard(name) {
     // TODO(hibbert) retrieve by numbered position
   });
 }
-harden(makeCorkboard);
+harden(makeSharedMap);
 
-export { makeCorkboard };
+export { makeSharedMap };

--- a/test/swingsetTests/gallery/bootstrap.js
+++ b/test/swingsetTests/gallery/bootstrap.js
@@ -55,12 +55,12 @@ function build(E, log) {
       alicePaymentP,
       buyerSeatReceipt,
       contractHostReceipt,
-    } = await E(aliceP).doTapFaucetAndOfferViaCorkboard(sharing, aliceDust);
+    } = await E(aliceP).doTapFaucetAndOfferViaSharedMap(sharing, aliceDust);
     // Don't start Bob until Alice has created and stored the buyerSeat
     const { bobRefundP, bobPixelP } = await Promise.all([
       contractHostReceipt,
       buyerSeatReceipt,
-    ]).then(_ => E(bobP).buyFromCorkBoard(sharing, bobDust));
+    ]).then(_ => E(bobP).buyFromSharedMap(sharing, bobDust));
     Promise.all([aliceRefundP, alicePaymentP, bobRefundP, bobPixelP]).then(
       _res => log('++ aliceSellsToBob done'),
       rej => log('++ aliceSellsToBob reject: ', rej),

--- a/test/swingsetTests/gallery/test-gallery.js
+++ b/test/swingsetTests/gallery/test-gallery.js
@@ -138,7 +138,7 @@ const expectedAliceSellsToBobLog = [
   '=> setup called',
   'starting aliceSellsToBob',
   'starting testAliceSellsToBob',
-  '++ alice.doTapFaucetAndOfferViaCorkboard starting',
+  '++ alice.doTapFaucetAndOfferViaSharedMap starting',
   'Alice collected 37 dust',
   'alice escrow wins: {"label":{"assay":{},"allegedName":"dust"},"extent":37} refs: null',
   'bob option wins: {"label":{"assay":{},"allegedName":"pixels"},"extent":[{"x":1,"y":4}]} refs: null',

--- a/test/swingsetTests/gallery/vat-alice.js
+++ b/test/swingsetTests/gallery/vat-alice.js
@@ -222,8 +222,8 @@ function makeAliceMaker(E, log, contractHost) {
           showPaymentBalance('alice pixel purse', pixelPurseP);
           showPaymentBalance('alice dust purse', dustPurseP);
         },
-        async doTapFaucetAndOfferViaCorkboard(sharingSvc, dustPurseP) {
-          log('++ alice.doTapFaucetAndOfferViaCorkboard starting');
+        async doTapFaucetAndOfferViaSharedMap(sharingSvc, dustPurseP) {
+          log('++ alice.doTapFaucetAndOfferViaSharedMap starting');
           const { pixelAssay } = await E(gallery).getAssays();
           const pixelPaymentP = E(gallery).tapFaucet();
 
@@ -232,8 +232,8 @@ function makeAliceMaker(E, log, contractHost) {
             dustPurseP,
           );
 
-          // store buyerInviteP and contractHost in corkboard
-          const cbP = E(sharingSvc).createBoard('MeetPoint');
+          // store buyerInviteP and contractHost in sharedMap
+          const cbP = E(sharingSvc).createSharedMap('MeetPoint');
           const buyerSeatReceipt = E(cbP).addEntry('buyerSeat', buyerInviteP);
           const contractHostReceipt = E(cbP).addEntry(
             'contractHost',

--- a/test/swingsetTests/gallery/vat-bob.js
+++ b/test/swingsetTests/gallery/vat-bob.js
@@ -46,12 +46,12 @@ function makeBobMaker(E, log) {
           const unitsP = await E(pixels).changeColorAll('#B695C0');
           return unitsP;
         },
-        async buyFromCorkBoard(sharingSvc, dustPurseP) {
+        async buyFromSharedMap(sharingSvc, dustPurseP) {
           const { pixelAssay, dustAssay } = await E(gallery).getAssays();
           const collect = makeCollect(E, log);
-          const boardP = E(sharingSvc).grabBoard('MeetPoint');
-          const contractHostP = E(boardP).lookup('contractHost');
-          const buyerInviteP = E(boardP).lookup('buyerSeat');
+          const sharedMapP = E(sharingSvc).grabSharedMap('MeetPoint');
+          const contractHostP = E(sharedMapP).lookup('contractHost');
+          const buyerInviteP = E(sharedMapP).lookup('buyerSeat');
           const buyerSeatP = E(contractHostP).redeem(buyerInviteP);
 
           const pixelPurseP = E(pixelAssay).makeEmptyPurse('purchase');

--- a/test/swingsetTests/sharingService/bootstrap.js
+++ b/test/swingsetTests/sharingService/bootstrap.js
@@ -2,44 +2,44 @@
 
 import harden from '@agoric/harden';
 
-import { makeCorkboard } from '../../../more/sharing/corkboard';
+import { makeSharedMap } from '../../../more/sharing/sharedMap';
 import { makeSharingService } from '../../../more/sharing/sharing';
 
 function build(E, log) {
-  function testCorkboardStorage() {
-    log('starting testCorkboardStorage');
-    const bb = makeCorkboard('whiteboard');
-    if (bb.getName() !== 'whiteboard') {
-      log(`bboard name should be 'whiteboard', not ${bb.getName()}`);
+  function testSharedMapStorage() {
+    log('starting testSharedMapStorage');
+    const wb = makeSharedMap('whiteboard');
+    if (wb.getName() !== 'whiteboard') {
+      log(`sharedMap name should be 'whiteboard', not ${wb.getName()}`);
     }
   }
 
   function testSharingStorage() {
     log('starting testSharingStorage');
     const h = makeSharingService();
-    if (h.grabBoard('missing') !== undefined) {
+    if (h.grabSharedMap('missing') !== undefined) {
       log('empty services should have no entries');
     }
-    const entry = h.createBoard('rendezvous');
+    const entry = h.createSharedMap('rendezvous');
     if (entry === undefined) {
-      log('should be able to create new new corkboard');
+      log('should be able to create new new sharedMap');
     }
     if (h.validate(entry) !== entry) {
-      log('expected new corkboard to validate');
+      log('expected new sharedMap to validate');
     }
-    const cork = h.grabBoard('rendezvous');
+    const cork = h.grabSharedMap('rendezvous');
     if (cork === undefined) {
-      log('should be able to grabBoard new corkboard');
+      log('should be able to grabSharedMap new sharedMap');
     }
     if (cork.getName() !== 'rendezvous') {
-      log('new board name should match');
+      log('new sharedMap name should match');
     }
 
     if (h.validate(cork) !== cork) {
-      log('expected corkboard to validate');
+      log('expected sharedMap to validate');
     }
 
-    const fakeBoard = harden({
+    const fakeSharedMap = harden({
       lookup(propertyName) {
         return `${propertyName}: value`;
       },
@@ -51,7 +51,7 @@ function build(E, log) {
       },
     });
     try {
-      h.validate(fakeBoard);
+      h.validate(fakeSharedMap);
     } catch (error) {
       log('expected validate to throw');
     }
@@ -82,8 +82,8 @@ function build(E, log) {
   const obj0 = {
     async bootstrap(argv, vats) {
       switch (argv[0]) {
-        case 'corkboard': {
-          return testCorkboardStorage();
+        case 'sharedMap': {
+          return testSharedMapStorage();
         }
         case 'sharing': {
           return testSharingStorage();

--- a/test/swingsetTests/sharingService/test-sharing.js
+++ b/test/swingsetTests/sharingService/test-sharing.js
@@ -15,20 +15,20 @@ async function main(withSES, basedir, argv) {
   return controller.dump();
 }
 
-const corkboardContentsGolden = [
+const sharedMapContentsGolden = [
   '=> setup called',
-  'starting testCorkboardStorage',
+  'starting testSharedMapStorage',
 ];
 
-test('run sharing Demo --corkboard contents', async t => {
-  const dump = await main(false, 'sharingService', ['corkboard']);
-  t.deepEquals(dump.log, corkboardContentsGolden);
+test('run sharing Demo --sharedMap contents', async t => {
+  const dump = await main(false, 'sharingService', ['sharedMap']);
+  t.deepEquals(dump.log, sharedMapContentsGolden);
   t.end();
 });
 
-test('run sharing Demo --corkboard contents', async t => {
-  const dump = await main(true, 'sharingService', ['corkboard']);
-  t.deepEquals(dump.log, corkboardContentsGolden);
+test('run sharing Demo --sharedMap contents', async t => {
+  const dump = await main(true, 'sharingService', ['sharedMap']);
+  t.deepEquals(dump.log, sharedMapContentsGolden);
   t.end();
 });
 

--- a/test/swingsetTests/sharingService/vat-alice.js
+++ b/test/swingsetTests/sharingService/vat-alice.js
@@ -8,8 +8,8 @@ function makeAliceMaker(E, _host, _log) {
       const alice = harden({
         shareSomething(someKey) {
           return E(sharingServiceP)
-            .createBoard(someKey)
-            .then(board => E(board).addEntry(someKey, 42));
+            .createSharedMap(someKey)
+            .then(sharedMap => E(sharedMap).addEntry(someKey, 42));
         },
       });
       return alice;

--- a/test/swingsetTests/sharingService/vat-bob.js
+++ b/test/swingsetTests/sharingService/vat-bob.js
@@ -8,9 +8,9 @@ function makeBobMaker(E, _host, _log) {
       const bob = harden({
         findSomething(key) {
           return E(sharingServiceP)
-            .grabBoard(key)
-            .then(board => {
-              return E(E(sharingServiceP).validate(board)).lookup(key);
+            .grabSharedMap(key)
+            .then(sharedMap => {
+              return E(E(sharingServiceP).validate(sharedMap)).lookup(key);
             });
         },
       });

--- a/test/swingsetTests/zoe/test-zoe.js
+++ b/test/swingsetTests/zoe/test-zoe.js
@@ -108,7 +108,7 @@ test('zoe - coveredCall - valid inputs - with SES', async t => {
   }
 });
 
-test('zoe - coveredCall - valid inputs - no SES', async t => {
+test.only('zoe - coveredCall - valid inputs - no SES', async t => {
   try {
     const startingExtents = [[3, 0], [0, 7]];
     const dump = await main(false, 'zoe', [

--- a/test/unitTests/more/sharing/test-sharing.js
+++ b/test/unitTests/more/sharing/test-sharing.js
@@ -3,17 +3,17 @@ import { makeSharingService } from '../../../../more/sharing/sharing';
 
 test('Sharing creation', t => {
   const sharingService = makeSharingService();
-  const first = sharingService.createBoard('first');
+  const first = sharingService.createSharedMap('first');
   t.assert(sharingService.validate(first));
   t.end();
 });
 
 test('Sharing repeated creation', t => {
   const sharingService = makeSharingService();
-  const first = sharingService.createBoard('first');
+  const first = sharingService.createSharedMap('first');
   t.assert(sharingService.validate(first));
   t.throws(
-    _ => sharingService.createBoard('first'),
+    _ => sharingService.createSharedMap('first'),
     /already exists/,
     'should throw on repeated call.',
   );
@@ -23,13 +23,13 @@ test('Sharing repeated creation', t => {
 test('Sharing grab value', t => {
   const sharingService = makeSharingService();
   const firstName = 'first';
-  const first = sharingService.createBoard(firstName);
+  const first = sharingService.createSharedMap(firstName);
   t.assert(sharingService.validate(first));
-  const second = sharingService.grabBoard(firstName);
+  const second = sharingService.grabSharedMap(firstName);
   t.assert(sharingService.validate(second));
   t.equals(second, first);
   t.throws(
-    _ => sharingService.grabBoard(firstName),
+    _ => sharingService.grabSharedMap(firstName),
     /has already been collected/,
     'should throw on repeated call.',
   );
@@ -40,7 +40,7 @@ test('Sharing validate non service', t => {
   const sharingService = makeSharingService();
   t.throws(
     _ => sharingService.validate([]),
-    /Unrecognized board:/,
+    /Unrecognized sharedMap:/,
     'throws on non sharing service.',
   );
   t.end();


### PR DESCRIPTION
This was supposed to follow the renaming of handoff service, but got lost somehow.