### PR TITLE
fix(zoe): have install accept a moduleFormat argument

### DIFF
--- a/core/zoe/zoe/zoe.js
+++ b/core/zoe/zoe/zoe.js
@@ -234,9 +234,22 @@ const makeZoe = async (additionalEndowments = {}) => {
     /**
      * Create an installation by safely evaluating the code and
      * registering it with Zoe.
+     *
+     * We have a moduleFormat to allow for different future formats
+     * without silent failures.
      */
-    install: code => {
-      const installation = evalContractCode(code, additionalEndowments);
+    install: (code, moduleFormat = 'getExport') => {
+      let installation;
+      switch (moduleFormat) {
+        case 'getExport': {
+          installation = evalContractCode(code, additionalEndowments);
+          break;
+        }
+        default: {
+          insist(false)`\
+Unimplemented installation moduleFormat ${moduleFormat}`;
+        }
+      }
       const installationHandle = adminState.addInstallation(installation);
       return installationHandle;
     },

--- a/test/swingsetTests/zoe/test-zoe.js
+++ b/test/swingsetTests/zoe/test-zoe.js
@@ -108,7 +108,7 @@ test('zoe - coveredCall - valid inputs - with SES', async t => {
   }
 });
 
-test.only('zoe - coveredCall - valid inputs - no SES', async t => {
+test('zoe - coveredCall - valid inputs - no SES', async t => {
   try {
     const startingExtents = [[3, 0], [0, 7]];
     const dump = await main(false, 'zoe', [


### PR DESCRIPTION
This is needed to be compatible with future bundle formats.

It apparently looks like this code can be simplified or eliminated, but it exists to explicitly declare what moduleFormats are accepted by Zoe.  When more formats are added or support for old ones is removed, this will be an important safeguard.
